### PR TITLE
SAF 36 - Cleanups 

### DIFF
--- a/apps/frontend/src/app/2_molecules/AssetAmountInput/AssetAmountInput.tsx
+++ b/apps/frontend/src/app/2_molecules/AssetAmountInput/AssetAmountInput.tsx
@@ -1,6 +1,12 @@
 import React, { FC, useCallback } from 'react';
 
-import { AmountInput, Paragraph, Select, SelectOption } from '@sovryn/ui';
+import {
+  AmountInput,
+  Paragraph,
+  ParagraphSize,
+  Select,
+  SelectOption,
+} from '@sovryn/ui';
 import { Decimalish } from '@sovryn/utils';
 
 import { AmountRenderer } from '../AmountRenderer/AmountRenderer';
@@ -43,7 +49,12 @@ export const AssetAmountInput: FC<AssetAmountInputProps> = ({
   return (
     <div>
       {label && (
-        <Paragraph className="mb-1 text-gray-30 font-medium">{label}</Paragraph>
+        <Paragraph
+          size={ParagraphSize.base}
+          className="mb-1 text-gray-30 font-medium"
+        >
+          {label}
+        </Paragraph>
       )}
 
       <div className="relative">

--- a/apps/frontend/src/app/2_molecules/AssetAmountPriceRenderer/AssetAmountPriceRenderer.tsx
+++ b/apps/frontend/src/app/2_molecules/AssetAmountPriceRenderer/AssetAmountPriceRenderer.tsx
@@ -1,0 +1,33 @@
+import React, { FC } from 'react';
+
+import classNames from 'classnames';
+
+import { Decimalish } from '@sovryn/utils';
+
+import { AmountRenderer } from '../AmountRenderer/AmountRenderer';
+
+type AssetAmountPriceRendererProps = {
+  value: Decimalish;
+  asset: string;
+  className?: string;
+};
+
+export const AssetAmountPriceRenderer: FC<AssetAmountPriceRendererProps> = ({
+  value,
+  asset,
+  className,
+}) => {
+  // TODO: get price in usd
+  const usdPrice = value;
+
+  return (
+    <div className={classNames('flex flex-col text-right', className)}>
+      <AmountRenderer value={value} suffix={asset} />
+      <AmountRenderer
+        value={usdPrice}
+        prefix={'$'}
+        className="text-gray-40 text-xs font-medium"
+      />
+    </div>
+  );
+};

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/BorrowAssetsList.constants.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/BorrowAssetsList.constants.tsx
@@ -4,6 +4,8 @@ import { t } from 'i18next';
 
 import { Align, HelperButton } from '@sovryn/ui';
 
+import { AmountRenderer } from '../../../../2_molecules/AmountRenderer/AmountRenderer';
+import { AssetAmountPriceRenderer } from '../../../../2_molecules/AssetAmountPriceRenderer/AssetAmountPriceRenderer';
 import { AssetRenderer } from '../../../../2_molecules/AssetRenderer/AssetRenderer';
 import { translations } from '../../../../../locales/i18n';
 import { BorrowPoolDetails } from './BorrowAssetsList.types';
@@ -25,6 +27,7 @@ export const COLUMNS_CONFIG = [
         showAssetLogo
         asset={pool.asset}
         className="lg:justify-start justify-end"
+        logoClassName="[&>svg]:h-8 [&>svg]:w-8 [&>svg]:mr-[10px]"
       />
     ),
   },
@@ -41,6 +44,12 @@ export const COLUMNS_CONFIG = [
         />
       </span>
     ),
+    cellRenderer: (position: BorrowPoolDetails) => (
+      <AssetAmountPriceRenderer
+        value={position.available}
+        asset={position.asset}
+      />
+    ),
   },
   {
     id: 'apr',
@@ -52,6 +61,9 @@ export const COLUMNS_CONFIG = [
         {t(pageTranslations.common.apr)}{' '}
         <HelperButton content={t(pageTranslations.common.aprInfo)} />
       </span>
+    ),
+    cellRenderer: (pool: BorrowPoolDetails) => (
+      <AmountRenderer value={pool.apr} suffix={'%'} />
     ),
   },
   {

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/components/BorrowAssetDetails/BorrowAssetDetails.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/components/BorrowAssetDetails/BorrowAssetDetails.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 
 import { t } from 'i18next';
 
-import { HelperButton } from '@sovryn/ui';
+import { HelperButton, SimpleTableRow } from '@sovryn/ui';
 
 import { AmountRenderer } from '../../../../../../2_molecules/AmountRenderer/AmountRenderer';
 import { translations } from '../../../../../../../locales/i18n';
@@ -18,36 +18,23 @@ type BorrowAssetDetailsProps = {
 export const BorrowAssetDetails: FC<BorrowAssetDetailsProps> = ({ pool }) => {
   return (
     <div className="space-y-3">
-      <div className="space-y-2">
+      <div>
         {/* APR */}
-        <div className="grid grid-cols-2">
-          <div className="flex items-center gap-1">
-            <span className="text-xs font-medium text-gray-30">
-              {t(pageTranslations.common.apr)}
+        <SimpleTableRow
+          label={
+            <span className="text-xs font-medium text-gray-30 items-center flex gap-1">
+              {t(pageTranslations.common.apr)}{' '}
+              <HelperButton content={t(pageTranslations.common.aprInfo)} />
             </span>
-            <HelperButton
-              content={t(pageTranslations.common.aprInfo)}
-              className="text-gray-30"
-            />
-          </div>
-
-          <div className="text-right text-xs text-gray-30 font-medium">
-            <AmountRenderer value={pool.apr} suffix={'%'} />
-          </div>
-        </div>
+          }
+          value={<AmountRenderer value={pool.apr} suffix={'%'} />}
+        />
 
         {/* Available */}
-        <div className="grid grid-cols-2">
-          <div className="flex items-center gap-1">
-            <span className="text-xs font-medium text-gray-30">
-              {t(pageTranslations.borrowAssetsList.available)}
-            </span>
-          </div>
-
-          <div className="text-right text-xs text-gray-30 font-medium">
-            <AmountRenderer value={pool.available} suffix={pool.asset} />
-          </div>
-        </div>
+        <SimpleTableRow
+          label={t(pageTranslations.borrowAssetsList.available)}
+          value={<AmountRenderer value={pool.available} suffix={pool.asset} />}
+        />
       </div>
 
       <BorrowAssetAction pool={pool} />

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/components/BorrowModal/BorrowForm.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/components/BorrowModal/BorrowForm.tsx
@@ -3,22 +3,19 @@ import React, { FC, useCallback, useMemo, useState } from 'react';
 import { t } from 'i18next';
 
 import {
-  AmountInput,
   Button,
   Checkbox,
   ErrorBadge,
   ErrorLevel,
   HealthBar,
   Link,
-  Paragraph,
-  ParagraphSize,
-  Select,
   SimpleTable,
   SimpleTableRow,
 } from '@sovryn/ui';
 import { Decimal } from '@sovryn/utils';
 
 import { AmountRenderer } from '../../../../../../2_molecules/AmountRenderer/AmountRenderer';
+import { AssetAmountInput } from '../../../../../../2_molecules/AssetAmountInput/AssetAmountInput';
 import { AssetRenderer } from '../../../../../../2_molecules/AssetRenderer/AssetRenderer';
 import { useDecimalAmountInput } from '../../../../../../../hooks/useDecimalAmountInput';
 import { translations } from '../../../../../../../locales/i18n';
@@ -91,67 +88,25 @@ export const BorrowForm: FC<BorrowFormProps> = () => {
   return (
     <form className="flex flex-col gap-6">
       <div className="space-y-3">
-        <div className="flex justify-between items-end">
-          <Paragraph size={ParagraphSize.base} className="font-medium">
-            {t(translations.aavePage.common.borrow)}
-          </Paragraph>
+        <AssetAmountInput
+          label={t(translations.aavePage.common.borrow)}
+          amountLabel={t(translations.common.amount)}
+          amountValue={borrowAmount}
+          onAmountChange={setBorrowAmount}
+          maxAmount={maximumBorrowAmount}
+          invalid={!isValidBorrowAmount}
+          assetValue={borrowAsset}
+          onAssetChange={onBorrowAssetChange}
+          assetOptions={borrowableAssetsOptions}
+        />
 
-          <span className="text-xs underline">
-            (Max{' '}
-            <AmountRenderer
-              value={maximumBorrowAmount}
-              suffix={borrowAsset}
-              prefix="~"
-            />
-            )
-          </span>
-        </div>
-
-        <div>
-          <div className="flex space-x-3">
-            <div className="text-right flex-grow space-y-1">
-              <AmountInput
-                label={t(translations.common.amount)}
-                value={borrowAmount}
-                onChangeText={setBorrowAmount}
-                placeholder="0"
-                invalid={!isValidBorrowAmount}
-              />
-              <div className=" pr-4">
-                <AmountRenderer
-                  className="text-gray-40"
-                  value={0} // TODO: usd equivalent
-                  prefix="$"
-                />
-              </div>
-            </div>
-
-            <Select
-              value={borrowAsset}
-              onChange={onBorrowAssetChange}
-              options={borrowableAssetsOptions}
-              labelRenderer={({ value }) => (
-                <AssetRenderer
-                  dataAttribute="borrow-asset-asset"
-                  showAssetLogo
-                  asset={value}
-                />
-              )}
-              className="min-w-[6.7rem]"
-              menuClassName="max-h-[10rem] sm:max-h-[20rem]"
-              dataAttribute="borrow-asset-select"
-            />
-          </div>
-        </div>
-        <div>
-          {!isValidBorrowAmount && (
-            <ErrorBadge
-              level={ErrorLevel.Critical}
-              message={t(pageTranslations.borrowForm.invalidAmountError)}
-              dataAttribute="borrow-amount-error"
-            />
-          )}
-        </div>
+        {!isValidBorrowAmount && (
+          <ErrorBadge
+            level={ErrorLevel.Critical}
+            message={t(pageTranslations.borrowForm.invalidAmountError)}
+            dataAttribute="borrow-amount-error"
+          />
+        )}
       </div>
 
       <SimpleTable>

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowPositionsList/BorrowPositionsList.constants.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowPositionsList/BorrowPositionsList.constants.tsx
@@ -4,6 +4,7 @@ import { t } from 'i18next';
 
 import { Align, HelperButton } from '@sovryn/ui';
 
+import { AmountRenderer } from '../../../../2_molecules/AmountRenderer/AmountRenderer';
 import { AssetRenderer } from '../../../../2_molecules/AssetRenderer/AssetRenderer';
 import { translations } from '../../../../../locales/i18n';
 import { BorrowPosition } from './BorrowPositionsList.types';
@@ -25,6 +26,7 @@ export const COLUMNS_CONFIG = [
         showAssetLogo
         asset={position.asset}
         className="lg:justify-start justify-end"
+        logoClassName="[&>svg]:h-8 [&>svg]:w-8 [&>svg]:mr-[10px]"
       />
     ),
   },
@@ -38,6 +40,9 @@ export const COLUMNS_CONFIG = [
         {t(pageTranslations.common.balance)}{' '}
       </span>
     ),
+    cellRenderer: (pool: BorrowPosition) => (
+      <AmountRenderer value={pool.balance} suffix={pool.asset} />
+    ),
   },
   {
     id: 'apr',
@@ -49,6 +54,9 @@ export const COLUMNS_CONFIG = [
         {t(translations.aavePage.common.apr)}{' '}
         <HelperButton content={t(pageTranslations.common.aprInfo)} />
       </span>
+    ),
+    cellRenderer: (position: BorrowPosition) => (
+      <AmountRenderer value={position.apr} suffix={'%'} />
     ),
   },
   {
@@ -62,7 +70,6 @@ export const COLUMNS_CONFIG = [
         <HelperButton content={t(pageTranslations.common.apyTypeInfo)} />
       </span>
     ),
-
     cellRenderer: (position: BorrowPosition) => (
       <span>{t(pageTranslations.common[position.apyType])}</span>
     ),

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowPositionsList/components/BorrowPositionDetails/BorrowPositionDetails.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowPositionsList/components/BorrowPositionDetails/BorrowPositionDetails.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 
 import { t } from 'i18next';
 
-import { HelperButton } from '@sovryn/ui';
+import { HelperButton, SimpleTableRow } from '@sovryn/ui';
 
 import { AmountRenderer } from '../../../../../../2_molecules/AmountRenderer/AmountRenderer';
 import { translations } from '../../../../../../../locales/i18n';
@@ -18,49 +18,31 @@ export const BorrowPositionDetails: FC<BorrowPositionDetailsProps> = ({
 }) => {
   return (
     <div className="space-y-3">
-      <div className="space-y-2">
+      <div>
         {/* Available */}
-        <div className="grid grid-cols-2">
-          <div className="flex items-center gap-1">
-            <span className="text-xs font-medium text-gray-30">
-              {t(translations.aavePage.common.balance)}
-            </span>
-          </div>
-
-          <div className="text-right text-xs text-gray-30 font-medium">
+        <SimpleTableRow
+          label={t(translations.aavePage.common.balance)}
+          value={
             <AmountRenderer value={position.balance} suffix={position.asset} />
-          </div>
-        </div>
+          }
+        />
 
         {/* APR */}
-        <div className="grid grid-cols-2">
-          <div className="flex items-center gap-1">
-            <span className="text-xs font-medium text-gray-30">
+        <SimpleTableRow
+          label={
+            <span className="text-xs font-medium text-gray-30 flex items-center gap-1">
               {t(translations.aavePage.common.apr)}
+              <HelperButton content={t(translations.aavePage.common.aprInfo)} />
             </span>
-            <HelperButton
-              content={t(translations.aavePage.common.aprInfo)}
-              className="text-gray-30"
-            />
-          </div>
-
-          <div className="text-right text-xs text-gray-30 font-medium">
-            <AmountRenderer value={position.apr} suffix="%" />
-          </div>
-        </div>
+          }
+          value={<AmountRenderer value={position.apr} suffix="%" />}
+        />
 
         {/* Apy type */}
-        <div className="grid grid-cols-2">
-          <div className="flex items-center gap-1">
-            <span className="text-xs font-medium text-gray-30">
-              {t(translations.aavePage.common.apyType)}
-            </span>
-          </div>
-
-          <div className="text-right text-xs text-gray-30 font-medium">
-            {t(translations.aavePage.common[position.apyType])}
-          </div>
-        </div>
+        <SimpleTableRow
+          label={t(translations.aavePage.common.apyType)}
+          value={t(translations.aavePage.common[position.apyType])}
+        />
       </div>
 
       <BorrowPositionAction position={position} />

--- a/apps/frontend/src/app/5_pages/AavePage/components/LendAssetsList/LendAssetsList.constants.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/LendAssetsList/LendAssetsList.constants.tsx
@@ -4,6 +4,7 @@ import { t } from 'i18next';
 
 import { Align, HelperButton, Icon, IconNames } from '@sovryn/ui';
 
+import { AmountRenderer } from '../../../../2_molecules/AmountRenderer/AmountRenderer';
 import { AssetRenderer } from '../../../../2_molecules/AssetRenderer/AssetRenderer';
 import { translations } from '../../../../../locales/i18n';
 import { LendPoolDetails } from './LendAssetsList.types';
@@ -25,6 +26,7 @@ export const COLUMNS_CONFIG = [
         showAssetLogo
         asset={pool.asset}
         className="lg:justify-start justify-end"
+        logoClassName="[&>svg]:h-8 [&>svg]:w-8 [&>svg]:mr-[10px]"
       />
     ),
   },
@@ -37,6 +39,9 @@ export const COLUMNS_CONFIG = [
         {t(pageTranslations.lendAssetsList.walletBalance)}{' '}
       </span>
     ),
+    cellRenderer: (pool: LendPoolDetails) => (
+      <AmountRenderer value={pool.walletBalance} suffix={pool.asset} />
+    ),
   },
   {
     id: 'apy',
@@ -47,6 +52,9 @@ export const COLUMNS_CONFIG = [
         {t(pageTranslations.common.apy)}{' '}
         <HelperButton content={t(pageTranslations.common.apyInfo)} />
       </span>
+    ),
+    cellRenderer: (pool: LendPoolDetails) => (
+      <AmountRenderer value={pool.apy} suffix={'%'} />
     ),
   },
   {

--- a/apps/frontend/src/app/5_pages/AavePage/components/LendAssetsList/components/LendAssetDetails/LendAssetDetails.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/LendAssetsList/components/LendAssetDetails/LendAssetDetails.tsx
@@ -1,8 +1,9 @@
 import React, { FC } from 'react';
 
+import classNames from 'classnames';
 import { t } from 'i18next';
 
-import { HelperButton, Icon, IconNames } from '@sovryn/ui';
+import { HelperButton, Icon, IconNames, SimpleTableRow } from '@sovryn/ui';
 
 import { AmountRenderer } from '../../../../../../2_molecules/AmountRenderer/AmountRenderer';
 import { translations } from '../../../../../../../locales/i18n';
@@ -16,56 +17,39 @@ type LendAssetDetailsProps = {
 export const LendAssetDetails: FC<LendAssetDetailsProps> = ({ pool }) => {
   return (
     <div className="space-y-3">
-      <div className="space-y-2">
+      <div>
         {/* Available */}
-        <div className="grid grid-cols-2">
-          <div className="flex items-center gap-1">
-            <span className="text-xs font-medium text-gray-30">
-              {t(translations.aavePage.lendAssetsList.walletBalance)}
-            </span>
-          </div>
-
-          <div className="text-right text-xs text-gray-30 font-medium">
+        <SimpleTableRow
+          label={t(translations.aavePage.lendAssetsList.walletBalance)}
+          value={
             <AmountRenderer value={pool.walletBalance} suffix={pool.asset} />
-          </div>
-        </div>
+          }
+        />
 
         {/* APY */}
-        <div className="grid grid-cols-2">
-          <div className="flex items-center gap-1">
-            <span className="text-xs font-medium text-gray-30">
+        <SimpleTableRow
+          label={
+            <span className="text-xs font-medium text-gray-30 flex gap-1 items-center">
               {t(translations.aavePage.common.apy)}
+              <HelperButton content={t(translations.aavePage.common.apyInfo)} />
             </span>
-            <HelperButton
-              content={t(translations.aavePage.common.apyInfo)}
-              className="text-gray-30"
-            />
-          </div>
-
-          <div className="text-right text-xs text-gray-30 font-medium">
-            <AmountRenderer value={pool.apy} suffix="%" />
-          </div>
-        </div>
+          }
+          value={<AmountRenderer value={pool.apy} suffix="%" />}
+        />
 
         {/* Can be collateral */}
-        <div className="grid grid-cols-2">
-          <div className="flex items-center gap-1">
-            <span className="text-xs font-medium text-gray-30">
-              {t(translations.aavePage.lendAssetsList.canBeCollateral)}
-            </span>
-          </div>
-
-          <div className="flex justify-end text-xs  font-medium">
-            {pool.canBeCollateral ? (
-              <Icon icon={IconNames.CHECK} className="w-[10px] text-positive" />
-            ) : (
-              <Icon
-                icon={IconNames.X_MARK}
-                className="w-[10px] text-negative"
-              />
-            )}
-          </div>
-        </div>
+        <SimpleTableRow
+          label={t(translations.aavePage.lendAssetsList.canBeCollateral)}
+          value={
+            <Icon
+              icon={pool.canBeCollateral ? IconNames.CHECK : IconNames.X_MARK}
+              className={classNames(
+                'w-[10px]',
+                pool.canBeCollateral ? 'text-positive' : 'text-negative',
+              )}
+            />
+          }
+        />
       </div>
 
       <LendAssetAction pool={pool} />

--- a/apps/frontend/src/app/5_pages/AavePage/components/LendPositionsList/LendPositionsList.constants.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/LendPositionsList/LendPositionsList.constants.tsx
@@ -4,6 +4,8 @@ import { t } from 'i18next';
 
 import { Align, HelperButton } from '@sovryn/ui';
 
+import { AmountRenderer } from '../../../../2_molecules/AmountRenderer/AmountRenderer';
+import { AssetAmountPriceRenderer } from '../../../../2_molecules/AssetAmountPriceRenderer/AssetAmountPriceRenderer';
 import { AssetRenderer } from '../../../../2_molecules/AssetRenderer/AssetRenderer';
 import { translations } from '../../../../../locales/i18n';
 import { LendPosition } from './LendPositionsList.types';
@@ -26,6 +28,7 @@ export const COLUMNS_CONFIG = [
         showAssetLogo
         asset={position.asset}
         className="lg:justify-start justify-end"
+        logoClassName="[&>svg]:h-8 [&>svg]:w-8 [&>svg]:mr-[10px]"
       />
     ),
   },
@@ -36,6 +39,12 @@ export const COLUMNS_CONFIG = [
     className: '[&_*]:mx-auto [&_*]:space-x-2', // center head
     title: (
       <span className="text-gray-30">{t(pageTranslations.common.balance)}</span>
+    ),
+    cellRenderer: (position: LendPosition) => (
+      <AssetAmountPriceRenderer
+        value={position.balance}
+        asset={position.asset}
+      />
     ),
   },
   {
@@ -48,6 +57,9 @@ export const COLUMNS_CONFIG = [
         {t(translations.aavePage.common.apy)}{' '}
         <HelperButton content={t(pageTranslations.common.apyInfo)} />
       </span>
+    ),
+    cellRenderer: (position: LendPosition) => (
+      <AmountRenderer value={position.balance} suffix={position.asset} />
     ),
   },
   {

--- a/apps/frontend/src/app/5_pages/AavePage/components/LendPositionsList/components/LendPositionDetails/LendPositionDetails.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/LendPositionsList/components/LendPositionDetails/LendPositionDetails.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 
 import { t } from 'i18next';
 
-import { HelperButton } from '@sovryn/ui';
+import { HelperButton, SimpleTableRow } from '@sovryn/ui';
 
 import { AmountRenderer } from '../../../../../../2_molecules/AmountRenderer/AmountRenderer';
 import { translations } from '../../../../../../../locales/i18n';
@@ -19,49 +19,34 @@ export const LendPositionDetails: FC<LendPositionDetailsProps> = ({
 }) => {
   return (
     <div className="space-y-3">
-      <div className="space-y-2">
+      <div>
         {/* Balance */}
-        <div className="grid grid-cols-2">
-          <div className="flex items-center gap-1">
-            <span className="text-xs font-medium text-gray-30">
-              {t(translations.aavePage.common.balance)}
-            </span>
-          </div>
-
-          <div className="text-right text-xs text-gray-30 font-medium">
+        <SimpleTableRow
+          label={t(translations.aavePage.common.balance)}
+          value={
             <AmountRenderer value={position.balance} suffix={position.asset} />
-          </div>
-        </div>
+          }
+        />
 
         {/* APY */}
-        <div className="grid grid-cols-2">
-          <div className="flex items-center gap-1">
-            <span className="text-xs font-medium text-gray-30">
+        <SimpleTableRow
+          label={
+            <span className="text-xs font-medium text-gray-30 flex gap-1 items-center">
               {t(translations.aavePage.common.apy)}
+              <HelperButton
+                content={t(translations.aavePage.common.apyInfo)}
+                className="text-gray-30"
+              />
             </span>
-            <HelperButton
-              content={t(translations.aavePage.common.apyInfo)}
-              className="text-gray-30"
-            />
-          </div>
-
-          <div className="text-right text-xs text-gray-30 font-medium">
-            <AmountRenderer value={position.apy} suffix={'%'} />
-          </div>
-        </div>
+          }
+          value={<AmountRenderer value={position.apy} suffix={'%'} />}
+        />
 
         {/* Can be collateral */}
-        <div className="grid grid-cols-2">
-          <div className="flex items-center gap-1">
-            <span className="text-xs font-medium text-gray-30">
-              {t(translations.aavePage.lendPositionsList.usedAsCollateral)}
-            </span>
-          </div>
-
-          <div className="flex justify-end">
-            <ToggleCollateralAction position={position} />
-          </div>
-        </div>
+        <SimpleTableRow
+          label={t(translations.aavePage.lendPositionsList.usedAsCollateral)}
+          value={<ToggleCollateralAction position={position} />}
+        />
       </div>
 
       <LendPositionAction position={position} />

--- a/apps/frontend/src/app/5_pages/AavePage/components/LendPositionsList/components/WithdrawModal/WithdrawForm.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/LendPositionsList/components/WithdrawModal/WithdrawForm.tsx
@@ -3,11 +3,9 @@ import React, { FC, useCallback, useMemo, useState } from 'react';
 import { t } from 'i18next';
 
 import {
-  AmountInput,
   Button,
   ErrorBadge,
   ErrorLevel,
-  Select,
   SimpleTable,
   SimpleTableRow,
   Tabs,
@@ -16,6 +14,7 @@ import {
 import { Decimal } from '@sovryn/utils';
 
 import { AmountRenderer } from '../../../../../../2_molecules/AmountRenderer/AmountRenderer';
+import { AssetAmountInput } from '../../../../../../2_molecules/AssetAmountInput/AssetAmountInput';
 import { AssetRenderer } from '../../../../../../2_molecules/AssetRenderer/AssetRenderer';
 import { useDecimalAmountInput } from '../../../../../../../hooks/useDecimalAmountInput';
 import { translations } from '../../../../../../../locales/i18n';
@@ -69,82 +68,41 @@ export const WithdrawForm: FC<WithdrawFormProps> = () => {
     [isValidWithdrawAmount, withdrawSize],
   );
 
-  const withdrawLabelRenderer = useCallback(
-    ({ value }) => (
-      <AssetRenderer
-        dataAttribute="withdraw-asset-select"
-        showAssetLogo
-        asset={value}
-      />
-    ),
-    [],
-  );
-
   return (
     <form className="flex flex-col gap-6">
-      <div className="space-y-3">
-        <div className="flex justify-between items-end">
-          <Tabs
-            type={TabType.secondary}
-            index={0}
-            items={[
-              // For now just withdraw is supported
-              {
-                activeClassName: 'text-primary-20',
-                dataAttribute: 'withdraw',
-                label: t(translations.common.withdraw),
-              },
-            ]}
+      <div className="space-y-2">
+        <Tabs
+          type={TabType.secondary}
+          index={0}
+          items={[
+            // For now just withdraw is supported
+            {
+              activeClassName: 'text-primary-20',
+              dataAttribute: 'withdraw',
+              label: t(translations.common.withdraw),
+            },
+          ]}
+        />
+
+        <div className="space-y-3">
+          <AssetAmountInput
+            amountValue={withdrawAmount}
+            onAmountChange={setWithdrawAmount}
+            invalid={!isValidWithdrawAmount}
+            maxAmount={maximumWithdrawAmount}
+            assetOptions={withdrawableAssetsOptions}
+            onAssetChange={onWithdrawAssetChange}
+            assetValue={withdrawAsset}
+            amountLabel={t(translations.common.amount)}
           />
-          <span className="text-xs underline">
-            (Max{' '}
-            <AmountRenderer
-              value={maximumWithdrawAmount}
-              suffix={withdrawAsset}
-              prefix="~"
+          {!isValidWithdrawAmount && (
+            <ErrorBadge
+              level={ErrorLevel.Critical}
+              message={t(pageTranslations.withdrawForm.invalidAmountError)}
+              dataAttribute="withdraw-amount-error"
             />
-            )
-          </span>
+          )}
         </div>
-
-        <div className="flex space-x-3">
-          <div className="text-right flex-grow space-y-1">
-            <AmountInput
-              label={t(translations.common.amount)}
-              value={withdrawAmount}
-              onChangeText={setWithdrawAmount}
-              placeholder="0"
-              invalid={!isValidWithdrawAmount}
-            />
-            <div className=" pr-4">
-              <AmountRenderer
-                className="text-gray-40"
-                value={0} // TODO: usd equivalent
-                prefix="$"
-              />
-            </div>
-          </div>
-
-          <Select
-            value={withdrawAsset}
-            onChange={onWithdrawAssetChange}
-            options={withdrawableAssetsOptions}
-            labelRenderer={withdrawLabelRenderer}
-            className="min-w-[6.7rem]"
-            menuClassName="max-h-[10rem] sm:max-h-[20rem]"
-            dataAttribute="withdraw-asset-select"
-          />
-        </div>
-      </div>
-
-      <div>
-        {!isValidWithdrawAmount && (
-          <ErrorBadge
-            level={ErrorLevel.Critical}
-            message={t(pageTranslations.withdrawForm.invalidAmountError)}
-            dataAttribute="withdraw-amount-error"
-          />
-        )}
       </div>
 
       <SimpleTable>

--- a/apps/frontend/src/locales/en/translations.json
+++ b/apps/frontend/src/locales/en/translations.json
@@ -795,7 +795,7 @@
             "collateralRatio": "Collateral ratio",
             "balance": "Balance",
             "apy": "APY",
-            "apyInfo": "The weighted average of APY for all supplied assets, including incentives.",
+            "apyInfo": "Compounding interest accrued by deposit or borrow on the lending pool",
             "apyType": "APY type",
             "apyTypeInfo": "Variable interest rate will fluctuate based on the market conditions. Recommended for short-term positions.",
             "apr": "APR",

--- a/apps/frontend/src/locales/en/translations.json
+++ b/apps/frontend/src/locales/en/translations.json
@@ -795,9 +795,9 @@
             "collateralRatio": "Collateral ratio",
             "balance": "Balance",
             "apy": "APY",
-            "apyInfo": "TODO:",
+            "apyInfo": "The weighted average of APY for all supplied assets, including incentives.",
             "apyType": "APY type",
-            "apyTypeInfo": "APY type info",
+            "apyTypeInfo": "Variable interest rate will fluctuate based on the market conditions. Recommended for short-term positions.",
             "apr": "APR",
             "aprInfo": "APR is estimated based on previous fees earned at the defined price range, if no trades were made previously or you have recently claimed fees/withdrawn liquidity, you may see 0 value",
             "details": "Details",
@@ -812,9 +812,9 @@
             "subtitle": "Borrow and earn interest by providing liquidity",
             "netWorth": "Net worth",
             "netApy": "Net API",
-            "netApyInfo": "Net apy info",
+            "netApyInfo": "Net APY is the combined effect of all supply and borrow positions on net worth, including incentives. It is possible to have a negative net APY if debt APY is higher than supply APY.",
             "collateralRatio": "Collateral ratio",
-            "collateralRatioInfo": "Collateral ratio info",
+            "collateralRatioInfo": "The collateral ratio defines the maximum amount of assets that can be borrowed with a specific collatera",
             "n/a": "N/A"
         },
         "borrowPositionsList": {
@@ -825,7 +825,7 @@
         "borrowAssetsList": {
             "title": "Assets to borrow",
             "available": "Available",
-            "availableInfo": "TODO:"
+            "availableInfo": "This is the total amount available for you to borrow. You can borrow based on your collateral and until the borrow cap is reached."
         },
         "lendPositionsList": {
             "title": "Your lending deposits",
@@ -848,7 +848,7 @@
             "tokenPrice": "{{token}} price",
             "walletBalance": "Wallet balance",
             "priceImpact": "Price impact",
-            "priceImpactInfo": "Price impact information TODO:",
+            "priceImpactInfo": "The impact your trade has on the market price of this pool.",
             "expectedAmountToRepay": "Expected amount to repay",
             "collateralToRepayWith": "Collateral to repay with"
         },


### PR DESCRIPTION

## Overview

Jira tickets: [SAF-36](https://wakeuplabs.atlassian.net/browse/SAF-36)

## Changelog

- Use `SimpleTableRow` in Details components instead of the custom version
- Add missing texts for info  and other translations. 
- Use `AssetAmountInput` component instead of duplicating custom implementation
- Adjust icon sizes to designs
- Create amount price renderer and add units to tables

## Screenshots

<img width="1352" alt="image" src="https://github.com/user-attachments/assets/864b686e-8b0e-447e-8379-10e5614cc303">
