### PR TITLE
Dashboard pool data integration

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -4,6 +4,8 @@
   "homepage": ".",
   "private": true,
   "dependencies": {
+    "@aave/contract-helpers": "^1.29.1",
+    "@aave/math-utils": "^1.29.1",
     "@apollo/client": "3.7.1",
     "@apollo/react-hooks": "4.0.0",
     "@loadable/component": "5.15.2",
@@ -54,6 +56,7 @@
     "react-slider": "2.0.6",
     "react-timer-hook": "3.0.7",
     "reactjs-localstorage": "1.0.1",
+    "reflect-metadata": "^0.2.2",
     "remark-gfm": "3.0.1",
     "rxjs": "7.5.6",
     "sanitize-html": "2.11.0",

--- a/apps/frontend/src/app/2_molecules/AssetAmountPriceRenderer/AssetAmountPriceRenderer.tsx
+++ b/apps/frontend/src/app/2_molecules/AssetAmountPriceRenderer/AssetAmountPriceRenderer.tsx
@@ -2,14 +2,14 @@ import React, { FC } from 'react';
 
 import classNames from 'classnames';
 
-import { Decimal, Decimalish } from '@sovryn/utils';
+import { Decimalish } from '@sovryn/utils';
 
 import { AmountRenderer } from '../AmountRenderer/AmountRenderer';
 
 type AssetAmountPriceRendererProps = {
   asset: string;
   value: Decimalish;
-  valueUSD?: Decimalish;
+  valueUSD: Decimalish;
   className?: string;
   valueClassName?: string;
   priceClassName?: string;
@@ -23,9 +23,6 @@ export const AssetAmountPriceRenderer: FC<AssetAmountPriceRendererProps> = ({
   valueClassName,
   priceClassName,
 }) => {
-  // TODO: get price in usd
-  const usdPrice = valueUSD ?? Decimal.from(0);
-
   return (
     <div className={className ?? 'flex flex-col text-right space-y-1'}>
       <AmountRenderer
@@ -35,7 +32,7 @@ export const AssetAmountPriceRenderer: FC<AssetAmountPriceRendererProps> = ({
         precision={2}
       />
       <AmountRenderer
-        value={usdPrice}
+        value={valueUSD}
         prefix={'$'}
         precision={2}
         className={classNames(

--- a/apps/frontend/src/app/2_molecules/AssetAmountPriceRenderer/AssetAmountPriceRenderer.tsx
+++ b/apps/frontend/src/app/2_molecules/AssetAmountPriceRenderer/AssetAmountPriceRenderer.tsx
@@ -2,34 +2,42 @@ import React, { FC } from 'react';
 
 import classNames from 'classnames';
 
-import { Decimalish } from '@sovryn/utils';
+import { Decimal, Decimalish } from '@sovryn/utils';
 
 import { AmountRenderer } from '../AmountRenderer/AmountRenderer';
 
 type AssetAmountPriceRendererProps = {
-  value: Decimalish;
   asset: string;
+  value: Decimalish;
+  valueUSD?: Decimalish;
   className?: string;
   valueClassName?: string;
   priceClassName?: string;
 };
 
 export const AssetAmountPriceRenderer: FC<AssetAmountPriceRendererProps> = ({
-  value,
   asset,
+  value,
+  valueUSD,
   className,
   valueClassName,
   priceClassName,
 }) => {
   // TODO: get price in usd
-  const usdPrice = value;
+  const usdPrice = valueUSD ?? Decimal.from(0);
 
   return (
     <div className={className ?? 'flex flex-col text-right space-y-1'}>
-      <AmountRenderer value={value} suffix={asset} className={valueClassName} />
+      <AmountRenderer
+        value={value}
+        suffix={asset}
+        className={valueClassName}
+        precision={2}
+      />
       <AmountRenderer
         value={usdPrice}
         prefix={'$'}
+        precision={2}
         className={classNames(
           'text-gray-40 text-xs font-medium',
           priceClassName,

--- a/apps/frontend/src/app/2_molecules/StatisticsCard/StatisticsCard.tsx
+++ b/apps/frontend/src/app/2_molecules/StatisticsCard/StatisticsCard.tsx
@@ -1,13 +1,11 @@
 import React, { FC } from 'react';
 
 import classNames from 'classnames';
-import { t } from 'i18next';
 import { ReactElement } from 'react-markdown/lib/react-markdown';
 
 import { HelperButton, Icon } from '@sovryn/ui';
 
 import { LinkIcon } from '../../1_atoms/Icons/Icons';
-import { translations } from '../../../locales/i18n';
 
 type StatisticsCardProps = {
   label: string;
@@ -43,7 +41,7 @@ export const StatisticsCard: FC<StatisticsCardProps> = ({
             )}
           </>
         ) : (
-          <span>{t(translations.common.na)}</span>
+          <span>---</span>
         )}
       </div>
     </div>

--- a/apps/frontend/src/app/5_pages/AavePage/AavePage.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/AavePage.tsx
@@ -54,14 +54,21 @@ const AavePage: FC = () => {
     }));
   }, [userReservesSummary]);
 
-  const borrowPools: BorrowPoolDetails[] = useMemo(
-    () =>
-      reserves.map(r => ({
+  const borrowPools: BorrowPoolDetails[] = useMemo(() => {
+    if (!userReservesSummary) {
+      return reserves.map(r => ({
         asset: r.symbol,
         apy: Decimal.from(r.variableBorrowAPY).mul(100),
-      })),
-    [reserves],
-  );
+      }));
+    } else {
+      return reserves.map(r => ({
+        asset: r.symbol,
+        apy: Decimal.from(r.variableBorrowAPY).mul(100),
+        available: userReservesSummary.borrowPower.div(r.priceInUSD),
+        availableUSD: userReservesSummary.borrowPower,
+      }));
+    }
+  }, [reserves, userReservesSummary]);
 
   const lendPools: LendPoolDetails[] = useMemo(
     () =>
@@ -132,6 +139,7 @@ const AavePage: FC = () => {
             )}
           >
             <BorrowPositionsList
+              eModeEnabled={userReservesSummary?.eModeEnabled ?? false}
               borrowPositions={borrowPositions}
               borrowBalance={userReservesSummary?.borrowBalance}
               borrowPowerUsed={userReservesSummary?.borrowPowerUsed}

--- a/apps/frontend/src/app/5_pages/AavePage/AavePage.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/AavePage.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useMemo, useState } from 'react';
 
 import classNames from 'classnames';
 import { t } from 'i18next';
@@ -12,6 +12,13 @@ import { BorrowPositionsList } from './components/BorrowPositionsList/BorrowPosi
 import { LendAssetsList } from './components/LendAssetsList/LendAssetsList';
 import { LendPositionsList } from './components/LendPositionsList/LendPositionsList';
 import { TopPanel } from './components/TopPanel/TopPanel';
+import { useAaveUserReservesData } from '../../../hooks/useAaveUserReservesData';
+import { LendPosition } from './components/LendPositionsList/LendPositionsList.types';
+import { BorrowPosition } from './components/BorrowPositionsList/BorrowPositionsList.types';
+import { useAaveReservesData } from '../../../hooks/useAaveReservesData';
+import { Decimal } from '@sovryn/utils';
+import { BorrowPoolDetails } from './components/BorrowAssetsList/BorrowAssetsList.types';
+import { LendPoolDetails } from './components/LendAssetsList/LendAssetsList.types';
 
 const pageTranslations = translations.aavePage;
 
@@ -21,7 +28,50 @@ enum ActiveTab {
 }
 
 const AavePage: FC = () => {
+  const { reserves } = useAaveReservesData();
+  const { userReservesSummary } = useAaveUserReservesData();
   const [activeTab, setActiveTab] = useState<ActiveTab>(ActiveTab.LEND);
+
+  const lendPositions: LendPosition[] = useMemo(() => {
+    if (!userReservesSummary) return [];
+    return userReservesSummary.suppliedAssets.map(s => ({
+      asset: s.asset,
+      apy: s.apy,
+      supplied: s.supplied,
+      suppliedUSD: s.suppliedUSD,
+      collateral: s.isCollateral,
+    }));
+  }, [userReservesSummary]);
+
+  const borrowPositions: BorrowPosition[] = useMemo(() => {
+    if (!userReservesSummary) return [];
+    return userReservesSummary.borrowedAssets.map(ba => ({
+      asset: ba.asset,
+      apy: ba.apy,
+      borrowed: ba.borrowed,
+      borrowedUSD: ba.borrowedUSD,
+      apyType: ba.apyType,
+    }));
+  }, [userReservesSummary]);
+
+  const borrowPools: BorrowPoolDetails[] = useMemo(
+    () =>
+      reserves.map(r => ({
+        asset: r.symbol,
+        apy: Decimal.from(r.variableBorrowAPY).mul(100),
+      })),
+    [reserves],
+  );
+
+  const lendPools: LendPoolDetails[] = useMemo(
+    () =>
+      reserves.map(r => ({
+        asset: r.symbol,
+        apy: Decimal.from(r.supplyAPY).mul(100),
+        canBeCollateral: r.usageAsCollateralEnabled,
+      })),
+    [reserves],
+  );
 
   return (
     <div className="w-full pb-6 2xl:px-12">
@@ -29,7 +79,11 @@ const AavePage: FC = () => {
         <title>{t(pageTranslations.meta.title)}</title>
       </Helmet>
 
-      <TopPanel />
+      <TopPanel
+        healthFactor={userReservesSummary?.healthFactor}
+        netApy={userReservesSummary?.netApy}
+        netWorth={userReservesSummary?.netWorth}
+      />
 
       <div className="pt-6 mt-6 space-y-6 lg:pt-0 lg:mt-0 lg:space-y-0">
         {/* Tab selector */}
@@ -61,8 +115,13 @@ const AavePage: FC = () => {
               'lg:block space-y-4',
             )}
           >
-            <LendPositionsList />
-            <LendAssetsList />
+            <LendPositionsList
+              lendPositions={lendPositions}
+              supplyBalance={userReservesSummary?.supplyBalance}
+              collateralBalance={userReservesSummary?.collateralBalance}
+              supplyWeightedApy={userReservesSummary?.supplyWeightedApy}
+            />
+            <LendAssetsList lendPools={lendPools} />
           </div>
 
           {/* Borrowing column */}
@@ -72,8 +131,13 @@ const AavePage: FC = () => {
               'lg:block space-y-4',
             )}
           >
-            <BorrowPositionsList />
-            <BorrowAssetsList />
+            <BorrowPositionsList
+              borrowPositions={borrowPositions}
+              borrowBalance={userReservesSummary?.borrowBalance}
+              borrowPowerUsed={userReservesSummary?.borrowPowerUsed}
+              borrowWeightedApy={userReservesSummary?.borrowWeightedApy}
+            />
+            <BorrowAssetsList borrowPools={borrowPools} />
           </div>
         </div>
       </div>

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/BorrowAssetsList.constants.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/BorrowAssetsList.constants.tsx
@@ -9,6 +9,7 @@ import { AssetRenderer } from '../../../../2_molecules/AssetRenderer/AssetRender
 import { translations } from '../../../../../locales/i18n';
 import { BorrowPoolDetails } from './BorrowAssetsList.types';
 import { BorrowAssetAction } from './components/BorrowAssetAction/BorrowAssetAction';
+import { AssetAmountPriceRenderer } from '../../../../2_molecules/AssetAmountPriceRenderer/AssetAmountPriceRenderer';
 
 const pageTranslations = translations.aavePage;
 
@@ -43,13 +44,17 @@ export const COLUMNS_CONFIG = [
         />
       </span>
     ),
-    cellRenderer: (position: BorrowPoolDetails) => (
-      <span>-</span>
-      // <AssetAmountPriceRenderer
-      //   value={1} // TODO: This should be calculated by the component
-      //   asset={position.asset}
-      // />
-    ),
+    cellRenderer: (position: BorrowPoolDetails) =>
+      position.available !== undefined &&
+      position.availableUSD !== undefined ? (
+        <AssetAmountPriceRenderer
+          value={position.available}
+          valueUSD={position.availableUSD}
+          asset={position.asset}
+        />
+      ) : (
+        <span>-</span>
+      ),
   },
   {
     id: 'apy',

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/BorrowAssetsList.constants.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/BorrowAssetsList.constants.tsx
@@ -5,7 +5,6 @@ import { t } from 'i18next';
 import { Align, HelperButton } from '@sovryn/ui';
 
 import { AmountRenderer } from '../../../../2_molecules/AmountRenderer/AmountRenderer';
-import { AssetAmountPriceRenderer } from '../../../../2_molecules/AssetAmountPriceRenderer/AssetAmountPriceRenderer';
 import { AssetRenderer } from '../../../../2_molecules/AssetRenderer/AssetRenderer';
 import { translations } from '../../../../../locales/i18n';
 import { BorrowPoolDetails } from './BorrowAssetsList.types';
@@ -45,14 +44,15 @@ export const COLUMNS_CONFIG = [
       </span>
     ),
     cellRenderer: (position: BorrowPoolDetails) => (
-      <AssetAmountPriceRenderer
-        value={position.available}
-        asset={position.asset}
-      />
+      <span>-</span>
+      // <AssetAmountPriceRenderer
+      //   value={1} // TODO: This should be calculated by the component
+      //   asset={position.asset}
+      // />
     ),
   },
   {
-    id: 'apr',
+    id: 'apy',
     sortable: true,
     align: Align.center,
     className: '[&_*]:mx-auto [&_*]:space-x-2', // center head
@@ -63,7 +63,7 @@ export const COLUMNS_CONFIG = [
       </span>
     ),
     cellRenderer: (pool: BorrowPoolDetails) => (
-      <AmountRenderer value={pool.apr} suffix={'%'} />
+      <AmountRenderer value={pool.apy} suffix={'%'} precision={2} />
     ),
   },
   {

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/BorrowAssetsList.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/BorrowAssetsList.tsx
@@ -23,7 +23,15 @@ export const BorrowAssetsList: FC<BorrowAssetsListProps> = ({
   const [orderOptions, setOrderOptions] = useState<OrderOptions>();
 
   const rowTitleRenderer = useCallback(
-    r => <AaveRowTitle asset={r.asset} value={r.apr} suffix="%" label="APY" />,
+    (r: BorrowPoolDetails) => (
+      <AaveRowTitle
+        asset={r.asset}
+        value={r.apy}
+        suffix="%"
+        label="APY"
+        precision={2}
+      />
+    ),
     [],
   );
   const mobileRenderer = useCallback(p => <BorrowAssetDetails pool={p} />, []);

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/BorrowAssetsList.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/BorrowAssetsList.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useEffect, useState } from 'react';
+import React, { FC, useCallback, useState } from 'react';
 
 import { t } from 'i18next';
 
@@ -9,7 +9,6 @@ import { translations } from '../../../../../locales/i18n';
 import { COLUMNS_CONFIG } from './BorrowAssetsList.constants';
 import { BorrowPoolDetails } from './BorrowAssetsList.types';
 import { BorrowAssetDetails } from './components/BorrowAssetDetails/BorrowAssetDetails';
-import { useAaveReservesData } from '../../../../../hooks/useAaveReservesData';
 
 const pageTranslations = translations.aavePage.borrowAssetsList;
 
@@ -22,11 +21,6 @@ export const BorrowAssetsList: FC<BorrowAssetsListProps> = ({
 }) => {
   const [open, setOpen] = useState<boolean>(true);
   const [orderOptions, setOrderOptions] = useState<OrderOptions>();
-  const { reserves } = useAaveReservesData();
-
-  useEffect(() => {
-    console.log(reserves.length ? reserves[0] : []);
-  }, [reserves]);
 
   const rowTitleRenderer = useCallback(
     r => <AaveRowTitle asset={r.asset} value={r.apr} suffix="%" label="APY" />,

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/BorrowAssetsList.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/BorrowAssetsList.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useState } from 'react';
+import React, { FC, useCallback, useEffect, useState } from 'react';
 
 import { t } from 'i18next';
 
@@ -9,36 +9,30 @@ import { translations } from '../../../../../locales/i18n';
 import { COLUMNS_CONFIG } from './BorrowAssetsList.constants';
 import { BorrowPoolDetails } from './BorrowAssetsList.types';
 import { BorrowAssetDetails } from './components/BorrowAssetDetails/BorrowAssetDetails';
+import { useAaveReservesData } from '../../../../../hooks/useAaveReservesData';
 
 const pageTranslations = translations.aavePage.borrowAssetsList;
 
-type BorrowAssetsListProps = {};
+type BorrowAssetsListProps = {
+  borrowPools: BorrowPoolDetails[];
+};
 
-export const BorrowAssetsList: FC<BorrowAssetsListProps> = () => {
+export const BorrowAssetsList: FC<BorrowAssetsListProps> = ({
+  borrowPools,
+}) => {
   const [open, setOpen] = useState<boolean>(true);
   const [orderOptions, setOrderOptions] = useState<OrderOptions>();
+  const { reserves } = useAaveReservesData();
+
+  useEffect(() => {
+    console.log(reserves.length ? reserves[0] : []);
+  }, [reserves]);
 
   const rowTitleRenderer = useCallback(
     r => <AaveRowTitle asset={r.asset} value={r.apr} suffix="%" label="APY" />,
     [],
   );
   const mobileRenderer = useCallback(p => <BorrowAssetDetails pool={p} />, []);
-
-  // TODO: just a mock for now
-  const borrowPools: BorrowPoolDetails[] = [
-    {
-      asset: 'BTC',
-      apr: 2.01,
-      available: 12.34,
-      availableUsd: 100,
-    },
-    {
-      asset: 'ETH',
-      apr: 2.01,
-      available: 12.34,
-      availableUsd: 100,
-    },
-  ];
 
   return (
     <Accordion

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/BorrowAssetsList.types.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/BorrowAssetsList.types.tsx
@@ -3,4 +3,6 @@ import { Decimal } from '@sovryn/utils';
 export type BorrowPoolDetails = {
   asset: string;
   apy: Decimal;
+  available?: Decimal;
+  availableUSD?: Decimal;
 };

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/BorrowAssetsList.types.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/BorrowAssetsList.types.tsx
@@ -1,6 +1,6 @@
+import { Decimal } from '@sovryn/utils';
+
 export type BorrowPoolDetails = {
   asset: string;
-  apr: number;
-  available: number;
-  availableUsd: number;
+  apy: Decimal;
 };

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/components/BorrowAssetDetails/BorrowAssetDetails.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/components/BorrowAssetDetails/BorrowAssetDetails.tsx
@@ -20,12 +20,12 @@ export const BorrowAssetDetails: FC<BorrowAssetDetailsProps> = ({ pool }) => {
   return (
     <div className="space-y-3">
       <div>
-        {/* APR */}
+        {/* APY */}
         <SimpleTableRow
           label={
             <span className="text-xs font-medium text-gray-30 items-center flex gap-1">
-              {t(pageTranslations.common.apr)}{' '}
-              <HelperButton content={t(pageTranslations.common.aprInfo)} />
+              {t(pageTranslations.common.apy)}{' '}
+              <HelperButton content={t(pageTranslations.common.apyInfo)} />
             </span>
           }
           value={<AmountRenderer value={pool.apy} suffix={'%'} />}
@@ -35,10 +35,15 @@ export const BorrowAssetDetails: FC<BorrowAssetDetailsProps> = ({ pool }) => {
         <SimpleTableRow
           label={t(pageTranslations.borrowAssetsList.available)}
           value={
-            <AssetAmountPriceRenderer
-              value={1} // TODO: this should be calculated by new hook
-              asset={pool.asset}
-            />
+            pool.available && pool.availableUSD ? (
+              <AssetAmountPriceRenderer
+                value={pool.available}
+                valueUSD={pool.availableUSD}
+                asset={pool.asset}
+              />
+            ) : (
+              <span>-</span>
+            )
           }
         />
       </div>

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/components/BorrowAssetDetails/BorrowAssetDetails.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/components/BorrowAssetDetails/BorrowAssetDetails.tsx
@@ -28,7 +28,7 @@ export const BorrowAssetDetails: FC<BorrowAssetDetailsProps> = ({ pool }) => {
               <HelperButton content={t(pageTranslations.common.aprInfo)} />
             </span>
           }
-          value={<AmountRenderer value={pool.apr} suffix={'%'} />}
+          value={<AmountRenderer value={pool.apy} suffix={'%'} />}
         />
 
         {/* Available */}
@@ -36,7 +36,7 @@ export const BorrowAssetDetails: FC<BorrowAssetDetailsProps> = ({ pool }) => {
           label={t(pageTranslations.borrowAssetsList.available)}
           value={
             <AssetAmountPriceRenderer
-              value={pool.available}
+              value={1} // TODO: this should be calculated by new hook
               asset={pool.asset}
             />
           }

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowPositionsList/BorrowPositionsList.constants.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowPositionsList/BorrowPositionsList.constants.tsx
@@ -41,22 +41,22 @@ export const COLUMNS_CONFIG = [
       </span>
     ),
     cellRenderer: (pool: BorrowPosition) => (
-      <AmountRenderer value={pool.balance} suffix={pool.asset} />
+      <AmountRenderer value={pool.borrowed} suffix={pool.asset} />
     ),
   },
   {
-    id: 'apr',
+    id: 'apy',
     sortable: true,
     align: Align.center,
     className: '[&_*]:mx-auto [&_*]:space-x-2', // center head
     title: (
       <span className="flex items-center gap-1 text-gray-30">
-        {t(translations.aavePage.common.apr)}{' '}
-        <HelperButton content={t(pageTranslations.common.aprInfo)} />
+        {t(translations.aavePage.common.apy)}{' '}
+        <HelperButton content={t(pageTranslations.common.apyInfo)} />
       </span>
     ),
     cellRenderer: (position: BorrowPosition) => (
-      <AmountRenderer value={position.apr} suffix={'%'} />
+      <AmountRenderer value={position.apy} suffix={'%'} precision={2} />
     ),
   },
   {

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowPositionsList/BorrowPositionsList.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowPositionsList/BorrowPositionsList.tsx
@@ -12,17 +12,25 @@ import { COLUMNS_CONFIG } from './BorrowPositionsList.constants';
 import { BorrowPosition } from './BorrowPositionsList.types';
 import { BorrowPositionDetails } from './components/BorrowPositionDetails/BorrowPositionDetails';
 import { EfficiencyModeCard } from './components/EfficiencyModeCard/EfficiencyModeCard';
+import { Decimal } from '@sovryn/utils';
 
 const pageTranslations = translations.aavePage;
 
-type BorrowPositionsListProps = {};
+type BorrowPositionsListProps = {
+  borrowPositions: BorrowPosition[];
+  borrowBalance?: Decimal;
+  borrowWeightedApy?: Decimal;
+  borrowPowerUsed?: Decimal;
+};
 
-export const BorrowPositionsList: FC<BorrowPositionsListProps> = () => {
+export const BorrowPositionsList: FC<BorrowPositionsListProps> = ({
+  borrowPositions,
+  borrowBalance,
+  borrowPowerUsed,
+  borrowWeightedApy,
+}) => {
   const { account } = useAccount();
   const [open, setOpen] = useState<boolean>(true);
-  const [balance] = useState(123.45); // TODO: mock
-  const [apy] = useState(2.05); // TODO: mock
-  const [borrowPowerUsed] = useState(2.05); // TODO: mock
   const [orderOptions, setOrderOptions] = useState<OrderOptions>();
 
   const rowTitleRenderer = useCallback(
@@ -34,22 +42,6 @@ export const BorrowPositionsList: FC<BorrowPositionsListProps> = () => {
     p => <BorrowPositionDetails position={p} />,
     [],
   );
-
-  // TODO: mocked values
-  const borrowPositions: BorrowPosition[] = [
-    {
-      asset: 'BTC',
-      apr: 2.24,
-      balance: 12.34,
-      apyType: 'variable',
-    },
-    {
-      asset: 'ETH',
-      apr: 2.33,
-      balance: 12.34,
-      apyType: 'fixed',
-    },
-  ];
 
   return (
     <Accordion
@@ -73,19 +65,19 @@ export const BorrowPositionsList: FC<BorrowPositionsListProps> = () => {
           <div className="flex flex-col gap-2 mb-2 lg:flex-row lg:gap-6 lg:mb-6">
             <PoolPositionStat
               label={t(pageTranslations.common.balance)}
-              value={balance}
+              value={borrowBalance ?? 0}
               prefix="$"
               precision={2}
             />
             <PoolPositionStat
               label={t(pageTranslations.common.apy)}
-              value={apy}
+              value={borrowWeightedApy ?? 0}
               suffix="%"
               precision={2}
             />
             <PoolPositionStat
               label={t(pageTranslations.borrowPositionsList.borrowPowerUsed)}
-              value={borrowPowerUsed}
+              value={borrowPowerUsed ?? 0}
               suffix="%"
               precision={2}
             />

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowPositionsList/BorrowPositionsList.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowPositionsList/BorrowPositionsList.tsx
@@ -3,6 +3,7 @@ import React, { FC, useCallback, useState } from 'react';
 import { t } from 'i18next';
 
 import { Accordion, OrderOptions, Paragraph, Table } from '@sovryn/ui';
+import { Decimal } from '@sovryn/utils';
 
 import { AaveRowTitle } from '../../../../2_molecules/AavePoolRowTitle/AavePoolRowTitle';
 import { useAccount } from '../../../../../hooks/useAccount';
@@ -12,7 +13,6 @@ import { COLUMNS_CONFIG } from './BorrowPositionsList.constants';
 import { BorrowPosition } from './BorrowPositionsList.types';
 import { BorrowPositionDetails } from './components/BorrowPositionDetails/BorrowPositionDetails';
 import { EfficiencyModeCard } from './components/EfficiencyModeCard/EfficiencyModeCard';
-import { Decimal } from '@sovryn/utils';
 
 const pageTranslations = translations.aavePage;
 
@@ -36,7 +36,14 @@ export const BorrowPositionsList: FC<BorrowPositionsListProps> = ({
   const [orderOptions, setOrderOptions] = useState<OrderOptions>();
 
   const rowTitleRenderer = useCallback(
-    r => <AaveRowTitle asset={r.asset} value={r.balance} suffix={r.asset} />,
+    (r: BorrowPosition) => (
+      <AaveRowTitle
+        asset={r.asset}
+        value={r.borrowed}
+        suffix={r.asset}
+        precision={2}
+      />
+    ),
     [],
   );
 

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowPositionsList/BorrowPositionsList.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowPositionsList/BorrowPositionsList.tsx
@@ -21,6 +21,7 @@ type BorrowPositionsListProps = {
   borrowBalance?: Decimal;
   borrowWeightedApy?: Decimal;
   borrowPowerUsed?: Decimal;
+  eModeEnabled: boolean;
 };
 
 export const BorrowPositionsList: FC<BorrowPositionsListProps> = ({
@@ -28,6 +29,7 @@ export const BorrowPositionsList: FC<BorrowPositionsListProps> = ({
   borrowBalance,
   borrowPowerUsed,
   borrowWeightedApy,
+  eModeEnabled,
 }) => {
   const { account } = useAccount();
   const [open, setOpen] = useState<boolean>(true);
@@ -50,7 +52,7 @@ export const BorrowPositionsList: FC<BorrowPositionsListProps> = ({
           <span>{t(pageTranslations.borrowPositionsList.title)}</span>
           <div className="hidden lg:flex gap-3">
             <span className="text-gray-30 font-medium text-sm">E-Mode</span>
-            <EfficiencyModeCard />
+            <EfficiencyModeCard enabled={eModeEnabled} />
           </div>
         </div>
       }
@@ -61,7 +63,10 @@ export const BorrowPositionsList: FC<BorrowPositionsListProps> = ({
     >
       {account ? (
         <>
-          <EfficiencyModeCard className="lg:hidden mb-3" />
+          <EfficiencyModeCard
+            enabled={eModeEnabled}
+            className="lg:hidden mb-3"
+          />
           <div className="flex flex-col gap-2 mb-2 lg:flex-row lg:gap-6 lg:mb-6">
             <PoolPositionStat
               label={t(pageTranslations.common.balance)}

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowPositionsList/BorrowPositionsList.types.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowPositionsList/BorrowPositionsList.types.tsx
@@ -1,6 +1,10 @@
+import { Decimal } from '@sovryn/utils';
+import { ApyType } from '../../../../../utils/aave';
+
 export type BorrowPosition = {
   asset: string;
-  balance: number;
-  apr: number;
-  apyType: 'variable' | 'fixed';
+  borrowed: Decimal;
+  borrowedUSD: Decimal;
+  apy: Decimal;
+  apyType: ApyType;
 };

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowPositionsList/components/BorrowPositionDetails/BorrowPositionDetails.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowPositionsList/components/BorrowPositionDetails/BorrowPositionDetails.tsx
@@ -25,7 +25,7 @@ export const BorrowPositionDetails: FC<BorrowPositionDetailsProps> = ({
           label={t(translations.aavePage.common.balance)}
           value={
             <AssetAmountPriceRenderer
-              value={position.balance}
+              value={position.borrowed}
               asset={position.asset}
             />
           }
@@ -39,7 +39,9 @@ export const BorrowPositionDetails: FC<BorrowPositionDetailsProps> = ({
               <HelperButton content={t(translations.aavePage.common.aprInfo)} />
             </span>
           }
-          value={<AmountRenderer value={position.apr} suffix="%" />}
+          value={
+            <AmountRenderer value={position.apy} suffix="%" precision={2} />
+          }
         />
 
         {/* Apy type */}

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowPositionsList/components/BorrowPositionDetails/BorrowPositionDetails.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowPositionsList/components/BorrowPositionDetails/BorrowPositionDetails.tsx
@@ -25,8 +25,9 @@ export const BorrowPositionDetails: FC<BorrowPositionDetailsProps> = ({
           label={t(translations.aavePage.common.balance)}
           value={
             <AssetAmountPriceRenderer
-              value={position.borrowed}
               asset={position.asset}
+              value={position.borrowed}
+              valueUSD={position.borrowedUSD}
             />
           }
         />

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowPositionsList/components/EfficiencyModeCard/EfficiencyModeCard.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowPositionsList/components/EfficiencyModeCard/EfficiencyModeCard.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC } from 'react';
 
 import classNames from 'classnames';
 import { t } from 'i18next';
@@ -18,13 +18,13 @@ import { translations } from '../../../../../../../locales/i18n';
 
 type EfficiencyModeCardProps = {
   className?: string;
+  enabled: boolean;
 };
 
 export const EfficiencyModeCard: FC<EfficiencyModeCardProps> = ({
   className,
+  enabled,
 }) => {
-  const [enabled] = useState(false);
-
   return (
     <Tooltip
       className={classNames('flex flex-row gap-2 items-center', className)}

--- a/apps/frontend/src/app/5_pages/AavePage/components/LendAssetsList/LendAssetsList.constants.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/LendAssetsList/LendAssetsList.constants.tsx
@@ -40,7 +40,8 @@ export const COLUMNS_CONFIG = [
       </span>
     ),
     cellRenderer: (pool: LendPoolDetails) => (
-      <AmountRenderer value={pool.walletBalance} suffix={pool.asset} />
+      <span>-</span> // TODO: should be a component on itself
+      // <AmountRenderer value={pool.walletBalance} suffix={pool.asset} />
     ),
   },
   {

--- a/apps/frontend/src/app/5_pages/AavePage/components/LendAssetsList/LendAssetsList.constants.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/LendAssetsList/LendAssetsList.constants.tsx
@@ -9,6 +9,7 @@ import { AssetRenderer } from '../../../../2_molecules/AssetRenderer/AssetRender
 import { translations } from '../../../../../locales/i18n';
 import { LendPoolDetails } from './LendAssetsList.types';
 import { LendAssetAction } from './components/LendAssetAction/LendAssetAction';
+import { AssetBalanceRenderer } from './components/AssetBalance/AssetBalance';
 
 const pageTranslations = translations.aavePage;
 
@@ -40,8 +41,7 @@ export const COLUMNS_CONFIG = [
       </span>
     ),
     cellRenderer: (pool: LendPoolDetails) => (
-      <span>-</span> // TODO: should be a component on itself
-      // <AmountRenderer value={pool.walletBalance} suffix={pool.asset} />
+      <AssetBalanceRenderer asset={pool.asset} />
     ),
   },
   {
@@ -55,7 +55,7 @@ export const COLUMNS_CONFIG = [
       </span>
     ),
     cellRenderer: (pool: LendPoolDetails) => (
-      <AmountRenderer value={pool.apy} suffix={'%'} />
+      <AmountRenderer value={pool.apy} suffix={'%'} precision={2} />
     ),
   },
   {

--- a/apps/frontend/src/app/5_pages/AavePage/components/LendAssetsList/LendAssetsList.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/LendAssetsList/LendAssetsList.tsx
@@ -23,7 +23,15 @@ export const LendAssetsList: FC<LendAssetsListProps> = ({ lendPools }) => {
 
   const mobileRenderer = useCallback(p => <LendAssetDetails pool={p} />, []);
   const rowTitleRenderer = useCallback(
-    r => <AaveRowTitle asset={r.asset} value={r.apy} suffix="%" label="APY" />,
+    (r: LendPoolDetails) => (
+      <AaveRowTitle
+        asset={r.asset}
+        value={r.apy}
+        suffix="%"
+        label="APY"
+        precision={2}
+      />
+    ),
     [],
   );
 

--- a/apps/frontend/src/app/5_pages/AavePage/components/LendAssetsList/LendAssetsList.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/LendAssetsList/LendAssetsList.tsx
@@ -12,9 +12,11 @@ import { LendAssetDetails } from './components/LendAssetDetails/LendAssetDetails
 
 const pageTranslations = translations.aavePage;
 
-type LendAssetsListProps = {};
+type LendAssetsListProps = {
+  lendPools: LendPoolDetails[];
+};
 
-export const LendAssetsList: FC<LendAssetsListProps> = () => {
+export const LendAssetsList: FC<LendAssetsListProps> = ({ lendPools }) => {
   const [open, setOpen] = useState<boolean>(true);
   const [showZeroBalances, setShowZeroBalances] = useState<boolean>(true);
   const [orderOptions, setOrderOptions] = useState<OrderOptions>();
@@ -24,22 +26,6 @@ export const LendAssetsList: FC<LendAssetsListProps> = () => {
     r => <AaveRowTitle asset={r.asset} value={r.apy} suffix="%" label="APY" />,
     [],
   );
-
-  // TODO: mocked values and filter
-  const lendPools: LendPoolDetails[] = [
-    {
-      asset: 'BTC',
-      apy: 2.02,
-      walletBalance: 12.34,
-      canBeCollateral: true,
-    },
-    {
-      asset: 'ETH',
-      apy: 2.02,
-      walletBalance: 12.34,
-      canBeCollateral: false,
-    },
-  ];
 
   return (
     <Accordion

--- a/apps/frontend/src/app/5_pages/AavePage/components/LendAssetsList/LendAssetsList.types.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/LendAssetsList/LendAssetsList.types.tsx
@@ -1,6 +1,7 @@
+import { Decimal } from '@sovryn/utils';
+
 export type LendPoolDetails = {
   asset: string;
-  walletBalance: number;
-  apy: number;
+  apy: Decimal;
   canBeCollateral: boolean;
 };

--- a/apps/frontend/src/app/5_pages/AavePage/components/LendAssetsList/components/AssetBalance/AssetBalance.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/LendAssetsList/components/AssetBalance/AssetBalance.tsx
@@ -1,0 +1,24 @@
+import React, { FC } from 'react';
+import { AmountRenderer } from '../../../../../../2_molecules/AmountRenderer/AmountRenderer';
+import { useAssetBalance } from '../../../../../../../hooks/useAssetBalance';
+import { useAccount } from '../../../../../../../hooks/useAccount';
+
+export type AssetBalanceRendererProps = {
+  asset: string;
+};
+
+export const AssetBalanceRenderer: FC<AssetBalanceRendererProps> = ({
+  asset,
+}) => {
+  const balance = useAssetBalance(asset);
+  const { account } = useAccount();
+
+  return account ? (
+    <AmountRenderer
+      value={balance.balance}
+      precision={balance.decimalPrecision}
+    />
+  ) : (
+    <span>-</span>
+  );
+};

--- a/apps/frontend/src/app/5_pages/AavePage/components/LendAssetsList/components/LendAssetDetails/LendAssetDetails.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/LendAssetsList/components/LendAssetDetails/LendAssetDetails.tsx
@@ -9,6 +9,7 @@ import { AmountRenderer } from '../../../../../../2_molecules/AmountRenderer/Amo
 import { translations } from '../../../../../../../locales/i18n';
 import { LendPoolDetails } from '../../LendAssetsList.types';
 import { LendAssetAction } from '../LendAssetAction/LendAssetAction';
+import { AssetBalanceRenderer } from '../AssetBalance/AssetBalance';
 
 type LendAssetDetailsProps = {
   pool: LendPoolDetails;
@@ -21,14 +22,7 @@ export const LendAssetDetails: FC<LendAssetDetailsProps> = ({ pool }) => {
         {/* Available */}
         <SimpleTableRow
           label={t(translations.aavePage.lendAssetsList.walletBalance)}
-          value={
-            // TODO: should be a component on itself
-            <span>-</span>
-            // <AssetAmountPriceRenderer
-            //   value={pool.walletBalance}
-            //   asset={pool.asset}
-            // />
-          }
+          value={<AssetBalanceRenderer asset={pool.asset} />}
         />
 
         {/* APY */}

--- a/apps/frontend/src/app/5_pages/AavePage/components/LendAssetsList/components/LendAssetDetails/LendAssetDetails.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/LendAssetsList/components/LendAssetDetails/LendAssetDetails.tsx
@@ -6,7 +6,6 @@ import { t } from 'i18next';
 import { HelperButton, Icon, IconNames, SimpleTableRow } from '@sovryn/ui';
 
 import { AmountRenderer } from '../../../../../../2_molecules/AmountRenderer/AmountRenderer';
-import { AssetAmountPriceRenderer } from '../../../../../../2_molecules/AssetAmountPriceRenderer/AssetAmountPriceRenderer';
 import { translations } from '../../../../../../../locales/i18n';
 import { LendPoolDetails } from '../../LendAssetsList.types';
 import { LendAssetAction } from '../LendAssetAction/LendAssetAction';
@@ -23,10 +22,12 @@ export const LendAssetDetails: FC<LendAssetDetailsProps> = ({ pool }) => {
         <SimpleTableRow
           label={t(translations.aavePage.lendAssetsList.walletBalance)}
           value={
-            <AssetAmountPriceRenderer
-              value={pool.walletBalance}
-              asset={pool.asset}
-            />
+            // TODO: should be a component on itself
+            <span>-</span>
+            // <AssetAmountPriceRenderer
+            //   value={pool.walletBalance}
+            //   asset={pool.asset}
+            // />
           }
         />
 

--- a/apps/frontend/src/app/5_pages/AavePage/components/LendPositionsList/LendPositionsList.constants.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/LendPositionsList/LendPositionsList.constants.tsx
@@ -42,7 +42,8 @@ export const COLUMNS_CONFIG = [
     ),
     cellRenderer: (position: LendPosition) => (
       <AssetAmountPriceRenderer
-        value={position.balance}
+        value={position.supplied}
+        valueUSD={position.suppliedUSD}
         asset={position.asset}
       />
     ),
@@ -59,7 +60,7 @@ export const COLUMNS_CONFIG = [
       </span>
     ),
     cellRenderer: (position: LendPosition) => (
-      <AmountRenderer value={position.balance} suffix={position.asset} />
+      <AmountRenderer value={position.apy} suffix={'%'} precision={2} />
     ),
   },
   {

--- a/apps/frontend/src/app/5_pages/AavePage/components/LendPositionsList/LendPositionsList.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/LendPositionsList/LendPositionsList.tsx
@@ -15,19 +15,27 @@ import { useAccount } from '../../../../../hooks/useAccount';
 import { translations } from '../../../../../locales/i18n';
 import { PoolPositionStat } from '../PoolPositionStat/PoolPositionStat';
 import { COLUMNS_CONFIG } from './LendPositionsList.constants';
-import { LendPosition } from './LendPositionsList.types';
 import { LendPositionDetails } from './components/LendPositionDetails/LendPositionDetails';
+import { Decimal } from '@sovryn/utils';
+import { LendPosition } from './LendPositionsList.types';
 
 const pageTranslations = translations.aavePage;
 
-type LendPositionsListProps = {};
+type LendPositionsListProps = {
+  supplyBalance?: Decimal;
+  supplyWeightedApy?: Decimal;
+  collateralBalance?: Decimal;
+  lendPositions: LendPosition[];
+};
 
-export const LendPositionsList: FC<LendPositionsListProps> = () => {
+export const LendPositionsList: FC<LendPositionsListProps> = ({
+  supplyBalance,
+  supplyWeightedApy,
+  collateralBalance,
+  lendPositions,
+}) => {
   const { account } = useAccount();
   const [open, setOpen] = useState<boolean>(true);
-  const [balance] = useState(100); // TODO: mocked data
-  const [apy] = useState(2.3); // TODO: mocked data
-  const [collateral] = useState(3); // TODO: mocked data
   const [orderOptions, setOrderOptions] = useState<OrderOptions>({
     orderBy: 'balance',
     orderDirection: OrderDirection.Asc,
@@ -41,22 +49,6 @@ export const LendPositionsList: FC<LendPositionsListProps> = () => {
     p => <LendPositionDetails position={p} />,
     [],
   );
-
-  // TODO: mocked data
-  const lendPositions: LendPosition[] = [
-    {
-      asset: 'BTC',
-      apy: 2.01,
-      balance: 12.34,
-      collateral: true,
-    },
-    {
-      asset: 'ETH',
-      apy: 2.04,
-      balance: 1.34,
-      collateral: false,
-    },
-  ];
 
   return (
     <Accordion
@@ -75,20 +67,20 @@ export const LendPositionsList: FC<LendPositionsListProps> = () => {
           <div className="flex flex-col gap-2 mb-2 lg:flex-row lg:gap-6 lg:mb-6">
             <PoolPositionStat
               label={t(pageTranslations.common.balance)}
-              value={balance}
+              value={supplyBalance ?? 0}
               prefix="$"
               precision={2}
             />
             <PoolPositionStat
               label={t(pageTranslations.common.apy)}
               labelInfo={t(pageTranslations.common.apyInfo)}
-              value={apy}
+              value={supplyWeightedApy ?? 0}
               suffix="%"
               precision={2}
             />
             <PoolPositionStat
               label={t(pageTranslations.common.collateral)}
-              value={collateral}
+              value={collateralBalance ?? 0}
               prefix="$"
               precision={2}
             />

--- a/apps/frontend/src/app/5_pages/AavePage/components/LendPositionsList/LendPositionsList.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/LendPositionsList/LendPositionsList.tsx
@@ -9,15 +9,15 @@ import {
   Paragraph,
   Table,
 } from '@sovryn/ui';
+import { Decimal } from '@sovryn/utils';
 
 import { AaveRowTitle } from '../../../../2_molecules/AavePoolRowTitle/AavePoolRowTitle';
 import { useAccount } from '../../../../../hooks/useAccount';
 import { translations } from '../../../../../locales/i18n';
 import { PoolPositionStat } from '../PoolPositionStat/PoolPositionStat';
 import { COLUMNS_CONFIG } from './LendPositionsList.constants';
-import { LendPositionDetails } from './components/LendPositionDetails/LendPositionDetails';
-import { Decimal } from '@sovryn/utils';
 import { LendPosition } from './LendPositionsList.types';
+import { LendPositionDetails } from './components/LendPositionDetails/LendPositionDetails';
 
 const pageTranslations = translations.aavePage;
 
@@ -42,7 +42,14 @@ export const LendPositionsList: FC<LendPositionsListProps> = ({
   });
 
   const rowTitleRenderer = useCallback(
-    r => <AaveRowTitle asset={r.asset} value={r.balance} suffix={r.asset} />,
+    (r: LendPosition) => (
+      <AaveRowTitle
+        asset={r.asset}
+        value={r.supplied}
+        suffix={r.asset}
+        precision={2}
+      />
+    ),
     [],
   );
   const mobileRenderer = useCallback(

--- a/apps/frontend/src/app/5_pages/AavePage/components/LendPositionsList/LendPositionsList.types.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/LendPositionsList/LendPositionsList.types.tsx
@@ -1,6 +1,9 @@
+import { Decimal } from '@sovryn/utils';
+
 export type LendPosition = {
   asset: string;
-  balance: number;
-  apy: number;
+  supplied: Decimal;
+  suppliedUSD: Decimal;
+  apy: Decimal;
   collateral: boolean;
 };

--- a/apps/frontend/src/app/5_pages/AavePage/components/LendPositionsList/components/LendPositionDetails/LendPositionDetails.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/LendPositionsList/components/LendPositionDetails/LendPositionDetails.tsx
@@ -26,7 +26,8 @@ export const LendPositionDetails: FC<LendPositionDetailsProps> = ({
           label={t(translations.aavePage.common.balance)}
           value={
             <AssetAmountPriceRenderer
-              value={position.balance}
+              value={position.supplied}
+              valueUSD={position.suppliedUSD}
               asset={position.asset}
             />
           }

--- a/apps/frontend/src/app/5_pages/AavePage/components/TopPanel/TopPanel.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/TopPanel/TopPanel.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC } from 'react';
 
 import { t } from 'i18next';
 
@@ -15,16 +15,22 @@ import { AmountRenderer } from '../../../../2_molecules/AmountRenderer/AmountRen
 import { StatisticsCard } from '../../../../2_molecules/StatisticsCard/StatisticsCard';
 import { useAccount } from '../../../../../hooks/useAccount';
 import { translations } from '../../../../../locales/i18n';
+import { Decimalish } from '@sovryn/utils';
 
 const pageTranslations = translations.aavePage.topPanel;
 
-type TopPanelProps = {};
+type TopPanelProps = {
+  netWorth?: Decimalish;
+  netApy?: Decimalish;
+  healthFactor?: Decimalish;
+};
 
-export const TopPanel: FC<TopPanelProps> = () => {
+export const TopPanel: FC<TopPanelProps> = ({
+  netApy,
+  netWorth,
+  healthFactor,
+}) => {
   const { account } = useAccount();
-  const [netWorth] = useState(1234567.58); // TODO: mock
-  const [netApy] = useState(2.69); // TODO: mock
-  const [collateralRatio] = useState(11); // TODO: mock
 
   return (
     <div className="w-full flex flex-col gap-6">
@@ -42,9 +48,10 @@ export const TopPanel: FC<TopPanelProps> = () => {
           <StatisticsCard
             label={t(pageTranslations.netWorth)}
             value={
-              account ? (
+              account && netWorth ? (
                 <AmountRenderer
                   prefix="$"
+                  precision={2}
                   value={netWorth}
                   className="text-2xl"
                 />
@@ -55,10 +62,11 @@ export const TopPanel: FC<TopPanelProps> = () => {
             <StatisticsCard
               label={t(pageTranslations.netApy)}
               value={
-                account ? (
+                account && netApy ? (
                   <AmountRenderer
                     suffix="%"
                     value={netApy}
+                    precision={2}
                     className="text-2xl"
                   />
                 ) : undefined
@@ -66,17 +74,17 @@ export const TopPanel: FC<TopPanelProps> = () => {
               help={t(pageTranslations.netApyInfo)}
             />
             <StatisticsCard
-              label={t(pageTranslations.collateralRatio)}
+              label={t(pageTranslations.healthFactor)}
               value={
-                account ? (
+                account && healthFactor ? (
                   <AmountRenderer
                     suffix="%"
-                    value={collateralRatio}
+                    precision={2}
+                    value={healthFactor}
                     className="text-2xl"
                   />
                 ) : undefined
               }
-              help={t(pageTranslations.collateralRatioInfo)}
             />
           </div>
         </div>

--- a/apps/frontend/src/app/5_pages/AaveReserveOverviewPage/components/WalletOverview/components/BorrowAction/BorrowAction.tsx
+++ b/apps/frontend/src/app/5_pages/AaveReserveOverviewPage/components/WalletOverview/components/BorrowAction/BorrowAction.tsx
@@ -16,6 +16,7 @@ type BorrowActionProps = {
 
 export const BorrowAction: FC<BorrowActionProps> = ({ asset }) => {
   const availableToBorrow = 0; // TODO: this is mocked
+  const availableToBorrowUsd = 0;
 
   const isBorrowDisabled = useMemo(() => {
     // TODO: add conditions
@@ -36,6 +37,7 @@ export const BorrowAction: FC<BorrowActionProps> = ({ asset }) => {
         </Paragraph>
         <AssetAmountPriceRenderer
           value={availableToBorrow}
+          valueUSD={availableToBorrowUsd}
           asset={asset}
           className="text-left flex flex-col"
           valueClassName="font-medium"

--- a/apps/frontend/src/app/5_pages/AaveReserveOverviewPage/components/WalletOverview/components/SupplyAction/SupplyAction.tsx
+++ b/apps/frontend/src/app/5_pages/AaveReserveOverviewPage/components/WalletOverview/components/SupplyAction/SupplyAction.tsx
@@ -16,6 +16,7 @@ type SupplyActionProps = {
 
 export const SupplyAction: FC<SupplyActionProps> = ({ asset }) => {
   const availableToSupply = 0; // TODO: this is mocked.
+  const availableToSupplyUSD = 0; // TODO: this is mocked.
 
   const isSupplyDisabled = useMemo(() => {
     // TODO: add conditions
@@ -36,8 +37,8 @@ export const SupplyAction: FC<SupplyActionProps> = ({ asset }) => {
         </Paragraph>
         <AssetAmountPriceRenderer
           value={availableToSupply}
+          valueUSD={availableToSupplyUSD}
           asset={asset}
-          //   className="text-left flex flex-col"
           valueClassName="font-medium"
         />
       </div>

--- a/apps/frontend/src/constants/aave.ts
+++ b/apps/frontend/src/constants/aave.ts
@@ -1,0 +1,12 @@
+import { ethers } from 'ethers';
+
+export const config = {
+  chainId: 137,
+  UiPoolDataProviderV3Address: '0x5598BbFA2f4fE8151f45bBA0a3edE1b54B51a0a9',
+  PoolAddressesProviderAddress: '0xa97684ead0e402dC232d5A977953DF7ECBaB3CDb',
+  assetsWhitelist: ['DAI', 'USDC', 'USDT', 'BTC', 'WETH', 'EURS', 'WMATIC'],
+  // TODO: temporary
+  provider: new ethers.providers.JsonRpcProvider(
+    'https://polygon-bor-rpc.publicnode.com',
+  ),
+};

--- a/apps/frontend/src/hooks/useAaveReservesData.tsx
+++ b/apps/frontend/src/hooks/useAaveReservesData.tsx
@@ -1,0 +1,67 @@
+import {
+  ReserveDataHumanized,
+  ReservesDataHumanized,
+  UiPoolDataProvider,
+} from '@aave/contract-helpers';
+import { formatReserves, FormatReserveUSDResponse } from '@aave/math-utils';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import dayjs from 'dayjs';
+
+import { config } from '../constants/aave';
+
+export const useAaveReservesData = () => {
+  const provider = config.provider; // TODO: replace with useAccount
+  const [reserves, setReserves] = useState<
+    (ReserveDataHumanized & FormatReserveUSDResponse)[]
+  >([]);
+  const [reservesData, setReservesData] =
+    useState<ReservesDataHumanized | null>(null);
+
+  const uiPoolDataProvider = useMemo(
+    () =>
+      provider
+        ? new UiPoolDataProvider({
+            provider,
+            uiPoolDataProviderAddress: config.UiPoolDataProviderV3Address,
+            chainId: config.chainId,
+          })
+        : null,
+    [provider],
+  );
+
+  useEffect(() => {
+    const fetchReservesData = async () => {
+      if (!uiPoolDataProvider) {
+        return;
+      }
+
+      const currentTimestamp = dayjs().unix();
+      const reservesData = await uiPoolDataProvider.getReservesHumanized({
+        lendingPoolAddressProvider: config.PoolAddressesProviderAddress,
+      });
+      const reserves = reservesData.reservesData.filter(r =>
+        config.assetsWhitelist.includes(r.symbol),
+      );
+      const formattedReserves = formatReserves({
+        reserves,
+        currentTimestamp,
+        marketReferenceCurrencyDecimals:
+          reservesData.baseCurrencyData.marketReferenceCurrencyDecimals,
+        marketReferencePriceInUsd:
+          reservesData.baseCurrencyData.marketReferenceCurrencyPriceInUsd,
+      });
+
+      setReserves(formattedReserves);
+      setReservesData({
+        baseCurrencyData: reservesData.baseCurrencyData,
+        reservesData: reserves,
+      });
+    };
+
+    fetchReservesData();
+  }, [uiPoolDataProvider]);
+
+  return { reserves, reservesData };
+};

--- a/apps/frontend/src/hooks/useAaveUserReservesData.tsx
+++ b/apps/frontend/src/hooks/useAaveUserReservesData.tsx
@@ -1,13 +1,18 @@
-import { UiPoolDataProvider } from '@aave/contract-helpers';
+import {
+  ReservesDataHumanized,
+  UiPoolDataProvider,
+} from '@aave/contract-helpers';
 import { formatUserSummary } from '@aave/math-utils';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import dayjs from 'dayjs';
+import { ethers } from 'ethers';
+
 import { config } from '../constants/aave';
-import { useAaveReservesData } from './useAaveReservesData';
-import { useAccount } from './useAccount';
 import { AaveUserReservesSummary } from '../utils/aave';
+import { Reserve, useAaveReservesData } from './useAaveReservesData';
+import { useAccount } from './useAccount';
 
 export const useAaveUserReservesData = () => {
   const provider = config.provider;
@@ -28,17 +33,13 @@ export const useAaveUserReservesData = () => {
     [provider],
   );
 
-  useEffect(() => {
-    const fetchPoolData = async () => {
-      if (
-        !uiPoolDataProvider ||
-        reserves.length === 0 ||
-        !signer ||
-        !reservesData
-      ) {
-        return;
-      }
-
+  const fetchPoolData = useCallback(
+    async (
+      uiPoolDataProvider: UiPoolDataProvider,
+      reserves: Reserve[],
+      reservesData: ReservesDataHumanized,
+      signer: ethers.Signer,
+    ) => {
       const userReservesData =
         await uiPoolDataProvider.getUserReservesHumanized({
           lendingPoolAddressProvider: config.PoolAddressesProviderAddress,
@@ -59,10 +60,22 @@ export const useAaveUserReservesData = () => {
           }),
         ),
       );
-    };
+    },
+    [],
+  );
 
-    fetchPoolData();
-  }, [uiPoolDataProvider, reserves, signer, reservesData]);
+  useEffect(() => {
+    if (
+      !uiPoolDataProvider ||
+      reserves.length === 0 ||
+      !signer ||
+      !reservesData
+    ) {
+      return;
+    }
+
+    fetchPoolData(uiPoolDataProvider, reserves, reservesData, signer);
+  }, [uiPoolDataProvider, reserves, signer, reservesData, fetchPoolData]);
 
   return { userReservesSummary };
 };

--- a/apps/frontend/src/hooks/useAaveUserReservesData.tsx
+++ b/apps/frontend/src/hooks/useAaveUserReservesData.tsx
@@ -1,0 +1,68 @@
+import { UiPoolDataProvider } from '@aave/contract-helpers';
+import { formatUserSummary } from '@aave/math-utils';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import dayjs from 'dayjs';
+import { config } from '../constants/aave';
+import { useAaveReservesData } from './useAaveReservesData';
+import { useAccount } from './useAccount';
+import { AaveUserReservesSummary } from '../utils/aave';
+
+export const useAaveUserReservesData = () => {
+  const provider = config.provider;
+  const { reserves, reservesData } = useAaveReservesData();
+  const { signer } = useAccount();
+  const [userReservesSummary, setUserReservesSummary] =
+    useState<AaveUserReservesSummary | null>(null);
+
+  const uiPoolDataProvider = useMemo(
+    () =>
+      provider
+        ? new UiPoolDataProvider({
+            provider,
+            uiPoolDataProviderAddress: config.UiPoolDataProviderV3Address,
+            chainId: config.chainId,
+          })
+        : null,
+    [provider],
+  );
+
+  useEffect(() => {
+    const fetchPoolData = async () => {
+      if (
+        !uiPoolDataProvider ||
+        reserves.length === 0 ||
+        !signer ||
+        !reservesData
+      ) {
+        return;
+      }
+
+      const userReservesData =
+        await uiPoolDataProvider.getUserReservesHumanized({
+          lendingPoolAddressProvider: config.PoolAddressesProviderAddress,
+          user: await signer.getAddress(),
+        });
+
+      setUserReservesSummary(
+        AaveUserReservesSummary.from(
+          formatUserSummary({
+            currentTimestamp: dayjs().unix(),
+            userReserves: userReservesData.userReserves,
+            userEmodeCategoryId: userReservesData.userEmodeCategoryId,
+            formattedReserves: reserves,
+            marketReferenceCurrencyDecimals:
+              reservesData.baseCurrencyData.marketReferenceCurrencyDecimals,
+            marketReferencePriceInUsd:
+              reservesData.baseCurrencyData.marketReferenceCurrencyPriceInUsd,
+          }),
+        ),
+      );
+    };
+
+    fetchPoolData();
+  }, [uiPoolDataProvider, reserves, signer, reservesData]);
+
+  return { userReservesSummary };
+};

--- a/apps/frontend/src/locales/en/translations.json
+++ b/apps/frontend/src/locales/en/translations.json
@@ -815,8 +815,7 @@
             "netWorth": "Net worth",
             "netApy": "Net API",
             "netApyInfo": "Net APY is the combined effect of all supply and borrow positions on net worth, including incentives. It is possible to have a negative net APY if debt APY is higher than supply APY.",
-            "collateralRatio": "Collateral ratio",
-            "collateralRatioInfo": "The collateral ratio defines the maximum amount of assets that can be borrowed with a specific collatera",
+            "healthFactor": "Health factor",
             "viewTransactions": "View transactions"
         },
         "borrowPositionsList": {

--- a/apps/frontend/src/utils/aave.ts
+++ b/apps/frontend/src/utils/aave.ts
@@ -140,6 +140,7 @@ export class AaveUserReservesSummary {
     borrowedBalance: Decimal,
     borrowPower: Decimal,
   ) {
+    if (borrowPower.eq(0)) return Decimal.from(0);
     return Decimal.from(borrowedBalance).div(borrowPower).mul(100);
   }
 
@@ -160,6 +161,7 @@ export class AaveUserReservesSummary {
     currentLiquidationThreshold: Decimal,
     borrowedBalance: Decimal,
   ): Decimal {
+    if (borrowedBalance.eq(0)) return Decimal.from(0);
     return collateral.mul(currentLiquidationThreshold).div(borrowedBalance);
   }
 
@@ -179,6 +181,7 @@ export class AaveUserReservesSummary {
       totalBorrowedUSD = totalBorrowedUSD.add(borrowedAmountUSD);
     });
 
+    if (totalBorrowedUSD.eq(0)) return Decimal.from(0);
     return weightedBorrowAPYSum.div(totalBorrowedUSD).mul(100);
   }
 
@@ -198,6 +201,7 @@ export class AaveUserReservesSummary {
       totalBorrowedUSD = totalBorrowedUSD.add(borrowedAmountUSD);
     });
 
+    if (totalBorrowedUSD.eq(0)) return Decimal.from(0);
     return weightedBorrowAPYSum.div(totalBorrowedUSD).mul(100);
   }
 

--- a/apps/frontend/src/utils/aave.ts
+++ b/apps/frontend/src/utils/aave.ts
@@ -1,0 +1,230 @@
+import { ReserveDataHumanized } from '@aave/contract-helpers';
+import {
+  FormatReserveUSDResponse,
+  FormatUserSummaryResponse,
+} from '@aave/math-utils';
+import { Decimal } from '@sovryn/utils';
+type UserSummary = FormatUserSummaryResponse<
+  ReserveDataHumanized & FormatReserveUSDResponse
+>;
+
+export enum ApyType {
+  VARIABLE = 'variable',
+  STABLE = 'stable',
+}
+
+export type SuppliedAsset = {
+  asset: string;
+  assetAddress: string;
+  apy: Decimal;
+  isCollateral: boolean;
+  supplied: Decimal;
+  suppliedUSD: Decimal;
+};
+
+export type BorrowedAsset = {
+  asset: string;
+  assetAddress: string;
+  apy: Decimal;
+  apyType: ApyType;
+  borrowed: Decimal;
+  borrowedUSD: Decimal;
+};
+
+export class AaveUserReservesSummary {
+  public netWorth: Decimal;
+  public netApy: Decimal;
+  public healthFactor: Decimal;
+  public supplyBalance: Decimal; // OK
+  public supplyWeightedApy: Decimal;
+  public collateralBalance: Decimal;
+  public borrowBalance: Decimal;
+  public borrowWeightedApy: Decimal;
+  public borrowPower: Decimal;
+  public borrowPowerUsed: Decimal;
+  public suppliedAssets: SuppliedAsset[];
+  public borrowedAssets: BorrowedAsset[];
+
+  constructor(private readonly userSummary: UserSummary) {
+    // balances
+    this.netWorth = Decimal.from(this.userSummary.netWorthUSD);
+    this.borrowBalance = Decimal.from(this.userSummary.totalBorrowsUSD);
+    this.supplyBalance = this.computeSuppliedBalance(
+      this.userSummary.userReservesData,
+    );
+    this.collateralBalance = this.computeCollateral(
+      this.userSummary.userReservesData,
+    );
+
+    // apy
+    this.supplyWeightedApy = this.computeWeightedSupplyApy(
+      this.userSummary.userReservesData,
+    );
+    this.borrowWeightedApy = this.computeWeightedBorrowApy(
+      this.userSummary.userReservesData,
+    );
+    this.netApy = this.computeNetApy(
+      this.supplyWeightedApy,
+      this.supplyBalance,
+      this.borrowWeightedApy,
+      this.borrowBalance,
+      this.netWorth,
+    );
+
+    // health and borrow status
+    this.borrowPower = this.computeBorrowPower(
+      Decimal.from(this.userSummary.availableBorrowsUSD),
+      this.borrowBalance,
+    );
+    this.borrowPowerUsed = this.computeBorrowPowerUsed(
+      this.borrowBalance,
+      this.borrowPower,
+    );
+    this.healthFactor = this.computeHealthFactor(
+      this.collateralBalance,
+      Decimal.from(this.userSummary.currentLiquidationThreshold),
+      this.borrowBalance,
+    );
+
+    // supplied and borrowed assets
+    this.suppliedAssets = this.computeSuppliedAssets(
+      this.userSummary.userReservesData,
+    );
+    this.borrowedAssets = this.computeBorrowedAssets(
+      this.userSummary.userReservesData,
+    );
+  }
+
+  static from(
+    userSummary: FormatUserSummaryResponse<
+      ReserveDataHumanized & FormatReserveUSDResponse
+    >,
+  ) {
+    return new AaveUserReservesSummary(userSummary);
+  }
+
+  private computeNetApy(
+    weightedSupplyApy: Decimal,
+    suppliedBalance: Decimal,
+    weightedBorrowApy: Decimal,
+    borrowedBalance: Decimal,
+    netWorthUsd: Decimal,
+  ): Decimal {
+    return weightedSupplyApy
+      .mul(suppliedBalance)
+      .div(netWorthUsd)
+      .sub(weightedBorrowApy.mul(borrowedBalance).div(netWorthUsd));
+  }
+
+  private computeSuppliedBalance(
+    reserves: UserSummary['userReservesData'],
+  ): Decimal {
+    return reserves.reduce(
+      (suppliedBalance, r) => suppliedBalance.add(r.underlyingBalanceUSD),
+      Decimal.from(0),
+    );
+  }
+
+  private computeBorrowPower(
+    availableBorrowsUSD: Decimal,
+    borrowedBalance: Decimal,
+  ) {
+    return Decimal.from(availableBorrowsUSD).add(borrowedBalance);
+  }
+
+  private computeBorrowPowerUsed(
+    borrowedBalance: Decimal,
+    borrowPower: Decimal,
+  ) {
+    return Decimal.from(borrowedBalance).div(borrowPower).mul(100);
+  }
+
+  private computeCollateral(
+    reserves: UserSummary['userReservesData'],
+  ): Decimal {
+    return reserves.reduce(
+      (collateral, r) =>
+        collateral.add(
+          r.usageAsCollateralEnabledOnUser ? r.underlyingBalanceUSD : 0,
+        ),
+      Decimal.from(0),
+    );
+  }
+
+  private computeHealthFactor(
+    collateral: Decimal,
+    currentLiquidationThreshold: Decimal,
+    borrowedBalance: Decimal,
+  ): Decimal {
+    return collateral.mul(currentLiquidationThreshold).div(borrowedBalance);
+  }
+
+  private computeWeightedBorrowApy(
+    reserves: UserSummary['userReservesData'],
+  ): Decimal {
+    let totalBorrowedUSD = Decimal.from(0);
+    let weightedBorrowAPYSum = Decimal.from(0);
+
+    reserves.forEach(reserve => {
+      const borrowedAmountUSD = Decimal.from(reserve.totalBorrowsUSD);
+      const borrowAPY = Decimal.from(reserve.reserve.variableBorrowAPY);
+
+      weightedBorrowAPYSum = weightedBorrowAPYSum.add(
+        borrowAPY.mul(borrowedAmountUSD),
+      );
+      totalBorrowedUSD = totalBorrowedUSD.add(borrowedAmountUSD);
+    });
+
+    return weightedBorrowAPYSum.div(totalBorrowedUSD).mul(100);
+  }
+
+  private computeWeightedSupplyApy(
+    reserves: UserSummary['userReservesData'],
+  ): Decimal {
+    let totalBorrowedUSD = Decimal.from(0);
+    let weightedBorrowAPYSum = Decimal.from(0);
+
+    reserves.forEach(reserve => {
+      const borrowedAmountUSD = Decimal.from(reserve.totalBorrowsUSD);
+      const borrowAPY = Decimal.from(reserve.reserve.supplyAPY);
+
+      weightedBorrowAPYSum = weightedBorrowAPYSum.add(
+        borrowAPY.mul(borrowedAmountUSD),
+      );
+      totalBorrowedUSD = totalBorrowedUSD.add(borrowedAmountUSD);
+    });
+
+    return weightedBorrowAPYSum.div(totalBorrowedUSD).mul(100);
+  }
+
+  private computeSuppliedAssets(
+    reserves: UserSummary['userReservesData'],
+  ): SuppliedAsset[] {
+    return reserves
+      .filter(r => Decimal.from(r.underlyingBalanceUSD).gt(0))
+      .map(r => ({
+        asset: r.reserve.symbol,
+        assetAddress: r.underlyingAsset,
+        apy: Decimal.from(r.reserve.supplyAPY).mul(100),
+        isCollateral: r.usageAsCollateralEnabledOnUser,
+        supplied: Decimal.from(r.underlyingBalance),
+        suppliedUSD: Decimal.from(r.underlyingBalanceUSD),
+      }));
+  }
+
+  private computeBorrowedAssets(
+    reserves: UserSummary['userReservesData'],
+  ): BorrowedAsset[] {
+    return reserves
+      .filter(r => Decimal.from(r.totalBorrowsUSD).gt(0))
+      .map(r => ({
+        asset: r.reserve.symbol,
+        assetAddress: r.underlyingAsset,
+        borrowed: Decimal.from(r.totalBorrows),
+        borrowedUSD: Decimal.from(r.totalBorrowsUSD),
+        apy: Decimal.from(r.reserve.variableBorrowAPY).mul(100),
+        apyType:
+          Number(r.variableBorrows) > 0 ? ApyType.VARIABLE : ApyType.STABLE,
+      }));
+  }
+}

--- a/apps/frontend/src/utils/aave.ts
+++ b/apps/frontend/src/utils/aave.ts
@@ -44,6 +44,7 @@ export class AaveUserReservesSummary {
   public borrowPowerUsed: Decimal;
   public suppliedAssets: SuppliedAsset[];
   public borrowedAssets: BorrowedAsset[];
+  public eModeEnabled: boolean;
 
   constructor(private readonly userSummary: UserSummary) {
     // balances
@@ -93,6 +94,9 @@ export class AaveUserReservesSummary {
     this.borrowedAssets = this.computeBorrowedAssets(
       this.userSummary.userReservesData,
     );
+
+    // emode
+    this.eModeEnabled = this.userSummary.userEmodeCategoryId !== 0;
   }
 
   static from(

--- a/apps/frontend/src/utils/graphql/bob/generated.tsx
+++ b/apps/frontend/src/utils/graphql/bob/generated.tsx
@@ -1,6 +1,5 @@
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = {

--- a/apps/frontend/src/utils/graphql/mynt/generated.tsx
+++ b/apps/frontend/src/utils/graphql/mynt/generated.tsx
@@ -1,6 +1,5 @@
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = {

--- a/apps/frontend/src/utils/graphql/rsk/generated.tsx
+++ b/apps/frontend/src/utils/graphql/rsk/generated.tsx
@@ -1,6 +1,5 @@
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = {

--- a/apps/frontend/src/utils/graphql/zero/generated.tsx
+++ b/apps/frontend/src/utils/graphql/zero/generated.tsx
@@ -1,6 +1,5 @@
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,18 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
+"@aave/contract-helpers@^1.29.1":
+  version "1.29.1"
+  resolved "https://registry.yarnpkg.com/@aave/contract-helpers/-/contract-helpers-1.29.1.tgz#34beab8afa35bbfc6168c78ced8317d96a493fe0"
+  integrity sha512-34z5CKpNdEx26G+DSezovdR3PyAf0v0Typbf2udaKG4GrOBgqbKqxr4zqS/dpFO5aAQJJ+nuEM19lKRK4sMcpg==
+  dependencies:
+    isomorphic-unfetch "^3.1.0"
+
+"@aave/math-utils@^1.29.1":
+  version "1.29.1"
+  resolved "https://registry.yarnpkg.com/@aave/math-utils/-/math-utils-1.29.1.tgz#fcb9499bd472bde7b80429c7dbe63d4358852697"
+  integrity sha512-a+L2+vjza/nH4BxUTzwDcoJH/Qr6UP+g+9YSwG7YKUgoVfdy8gJs5VyXjfDDEVe9lMeZuPJq7CqrgV4P2M6Nkg==
+
 "@actions/core@^1.10.0":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.10.0.tgz#44551c3c71163949a2f06e94d9ca2157a0cfac4f"
@@ -21035,6 +21047,11 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+reflect-metadata@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.2.2.tgz#400c845b6cba87a21f2c65c4aeb158f4fa4d9c5b"
+  integrity sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==
+
 refractor@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/refractor/-/refractor-3.6.0.tgz#ac318f5a0715ead790fcfb0c71f4dd83d977935a"
@@ -21600,14 +21617,7 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@6:
-  version "6.6.7"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
-  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
-  dependencies:
-    tslib "^1.9.0"
-
-rxjs@7.5.6, rxjs@^7.5.5, rxjs@^7.5.6:
+rxjs@6, rxjs@7.5.6, rxjs@^7.5.5, rxjs@^7.5.6:
   version "7.5.6"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.6.tgz#0446577557862afd6903517ce7cae79ecb9662bc"
   integrity sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==
@@ -23492,7 +23502,7 @@ tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@1.14.1, tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@1.14.1, tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
## Overview

Jira tickets: 
[SAF-29](https://wakeuplabs.atlassian.net/browse/SAF-29)
[SAF-30](https://wakeuplabs.atlassian.net/browse/SAF-30)
[SAF-32](https://wakeuplabs.atlassian.net/browse/SAF-32)

Pull data from contracts, copute user summaries and display data in dashboard tables removing mocks. At this point I'm using a polygon connection for easiness to try, compare, that can be easily swapped whenever bob contracts are ready.

## Demo

Point is to see same values as I get on aave. Tokens will change so for example about icons should not matter

<img width="1352" alt="image" src="https://github.com/user-attachments/assets/f83f9885-f990-439d-95f8-64fde39c8184">
<img width="1352" alt="image" src="https://github.com/user-attachments/assets/63307b4a-d282-470a-8667-464e31cfc4f8">

<img width="1352" alt="image" src="https://github.com/user-attachments/assets/413309fe-584b-433a-9910-a7f926df2c78">
<img width="1352" alt="image" src="https://github.com/user-attachments/assets/84298490-043f-4e73-858f-0bd8d83ff999">
