### PR TITLE
fix(native): show WETH

### DIFF
--- a/apps/frontend/src/app/5_pages/AavePage/AavePage.utils.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/AavePage.utils.tsx
@@ -157,3 +157,6 @@ export const sortRowsByOrderOptions = (
       : -direction,
   );
 };
+
+export const formatFloorNumber = (num: Decimal, precision = 2) =>
+  Math.floor(num.toNumber() * 10 ** precision) / 10 ** precision;

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/components/BorrowForm/BorrowForm.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowAssetsList/components/BorrowForm/BorrowForm.tsx
@@ -101,9 +101,9 @@ export const BorrowForm: FC<BorrowFormProps> = ({ asset, onComplete }) => {
     ],
   );
 
-  const borrowApr = useMemo(
-    () => Decimal.from(borrowReserve?.reserve.variableBorrowAPR ?? 0).mul(100),
-    [borrowReserve?.reserve.variableBorrowAPR],
+  const borrowApy = useMemo(
+    () => Decimal.from(borrowReserve?.reserve.variableBorrowAPY ?? 0).mul(100),
+    [borrowReserve?.reserve.variableBorrowAPY],
   );
 
   const isValidBorrowAmount = useMemo(
@@ -159,8 +159,8 @@ export const BorrowForm: FC<BorrowFormProps> = ({ asset, onComplete }) => {
 
       <SimpleTable>
         <SimpleTableRow
-          label={t(translations.aavePage.borrowForm.borrowApr)}
-          value={<AmountRenderer value={borrowApr} suffix="%" precision={2} />}
+          label={t(translations.aavePage.borrowForm.borrowApy)}
+          value={<AmountRenderer value={borrowApy} suffix="%" precision={2} />}
         />
       </SimpleTable>
 

--- a/apps/frontend/src/app/5_pages/AavePage/components/BorrowPositionsList/components/BorrowRateModeSelect/BorrowRateModeSelect.tsx
+++ b/apps/frontend/src/app/5_pages/AavePage/components/BorrowPositionsList/components/BorrowRateModeSelect/BorrowRateModeSelect.tsx
@@ -10,6 +10,7 @@ import { BOB_CHAIN_ID } from '../../../../../../../config/chains';
 import { useAaveBorrow } from '../../../../../../../hooks/aave/useAaveBorrow';
 import { translations } from '../../../../../../../locales/i18n';
 import { BorrowRateMode } from '../../../../../../../types/aave';
+import { formatFloorNumber } from '../../../../AavePage.utils';
 import { BorrowPosition } from '../../BorrowPositionsList.types';
 
 type BorrowRateModeSelectProps = {
@@ -25,7 +26,7 @@ export const BorrowRateModeSelect: FC<BorrowRateModeSelectProps> = ({
     const borrowRateModeOptions = [
       {
         label: t(translations.aavePage.borrowPositionsList.selectVariableApy, {
-          apy: position.variableApy.toString(2),
+          apy: formatFloorNumber(position.variableApy),
         }),
         value: String(BorrowRateMode.VARIABLE),
       },
@@ -38,7 +39,7 @@ export const BorrowRateModeSelect: FC<BorrowRateModeSelectProps> = ({
     ) {
       borrowRateModeOptions.push({
         label: t(translations.aavePage.borrowPositionsList.selectStableApy, {
-          apy: position.stableApy.toString(2),
+          apy: formatFloorNumber(position.stableApy),
         }),
         value: String(BorrowRateMode.STABLE),
       });

--- a/apps/frontend/src/hooks/aave/useAaveReservesData.tsx
+++ b/apps/frontend/src/hooks/aave/useAaveReservesData.tsx
@@ -13,7 +13,6 @@ import { getProvider } from '@sovryn/ethers-provider';
 import { BOB_CHAIN_ID } from '../../config/chains';
 
 import { AAVE_CONTRACT_ADDRESSES } from '../../constants/aave';
-import { ETH, WETH } from '../../constants/currencies';
 
 export type Reserve = ReserveDataHumanized & FormatReserveUSDResponse;
 export type ReserveData = { reserves: Reserve[]; loading: boolean };
@@ -43,12 +42,7 @@ export const useAaveReservesData = (): ReserveData => {
         reservesData.baseCurrencyData.marketReferenceCurrencyPriceInUsd,
     });
 
-    setReserves(
-      // rename weth to eth. We don't expose WETH through ui.
-      formattedReserves.map(r =>
-        r.symbol === WETH ? { ...r, symbol: ETH } : r,
-      ),
-    );
+    setReserves(formattedReserves);
   }, [setReserves]);
 
   useEffect(() => {

--- a/apps/frontend/src/locales/en/translations.json
+++ b/apps/frontend/src/locales/en/translations.json
@@ -909,7 +909,7 @@
             "collateralToRepayWith": "Collateral to repay with"
         },
         "borrowForm": {
-            "borrowApr": "Borrow APR",
+            "borrowApy": "Borrow APY",
             "learnMore":"Learn more",
             "collateralRatio": "Collateral ratio",
             "liquidationPrice": "Liquidation price",

--- a/apps/frontend/src/utils/aave/AaveBorrowTransactionsFactory.ts
+++ b/apps/frontend/src/utils/aave/AaveBorrowTransactionsFactory.ts
@@ -9,7 +9,6 @@ import {
   Transaction,
   TransactionType,
 } from '../../app/3_organisms/TransactionStepDialog/TransactionStepDialog.types';
-import { AAVE_CONTRACT_ADDRESSES } from '../../constants/aave';
 import { translations } from '../../locales/i18n';
 import { BorrowRateMode, TransactionFactoryOptions } from '../../types/aave';
 
@@ -54,10 +53,7 @@ export class AaveBorrowTransactionsFactory {
     rateMode: BorrowRateMode,
     opts?: TransactionFactoryOptions,
   ): Promise<Transaction[]> {
-    if (
-      asset.isNative ||
-      asset.address.toLowerCase() === AAVE_CONTRACT_ADDRESSES.WETH.toLowerCase()
-    ) {
+    if (asset.isNative) {
       return this.borrowNative(amount, rateMode, opts);
     } else return this.borrowToken(asset, amount, rateMode, opts);
   }

--- a/apps/frontend/src/utils/aave/AaveRepayTransactionsFactory.ts
+++ b/apps/frontend/src/utils/aave/AaveRepayTransactionsFactory.ts
@@ -9,10 +9,7 @@ import {
   Transaction,
   TransactionType,
 } from '../../app/3_organisms/TransactionStepDialog/TransactionStepDialog.types';
-import {
-  AAVE_CONTRACT_ADDRESSES,
-  REPAY_ALL_ETH_SURPLUS_AAVE,
-} from '../../constants/aave';
+import { REPAY_ALL_ETH_SURPLUS_AAVE } from '../../constants/aave';
 import { translations } from '../../locales/i18n';
 import { BorrowRateMode, TransactionFactoryOptions } from '../../types/aave';
 import { prepareApproveTransaction } from '../transactions';
@@ -50,10 +47,7 @@ export class AaveRepayTransactionsFactory {
     borrowRateMode: BorrowRateMode,
     opts?: TransactionFactoryOptions,
   ): Promise<Transaction[]> {
-    if (
-      token.isNative ||
-      token.address.toLowerCase() === AAVE_CONTRACT_ADDRESSES.WETH.toLowerCase()
-    ) {
+    if (token.isNative) {
       return this.repayNative(amount, isEntireDebt, borrowRateMode, opts);
     } else
       return this.repayToken(token, amount, isEntireDebt, borrowRateMode, opts);

--- a/apps/frontend/src/utils/aave/AaveSupplyTransactionsFactory.ts
+++ b/apps/frontend/src/utils/aave/AaveSupplyTransactionsFactory.ts
@@ -46,10 +46,7 @@ export class AaveSupplyTransactionsFactory {
     amount: BigNumber,
     opts?: TransactionFactoryOptions,
   ): Promise<Transaction[]> {
-    if (
-      token.isNative ||
-      token.address.toLowerCase() === AAVE_CONTRACT_ADDRESSES.WETH.toLowerCase()
-    ) {
+    if (token.isNative) {
       return this.supplyNative(amount, opts);
     } else return this.supplyToken(token, amount, opts);
   }

--- a/apps/frontend/src/utils/aave/AaveUserReservesSummary.ts
+++ b/apps/frontend/src/utils/aave/AaveUserReservesSummary.ts
@@ -200,7 +200,7 @@ export class AaveUserReservesSummaryFactory {
 
       reserves: await Promise.all(
         userSummary.userReservesData.map(async r => {
-          const symbol = r.reserve.symbol === 'WETH' ? 'ETH' : r.reserve.symbol;
+          const symbol = r.reserve.symbol;
           const asset = await getAssetData(symbol, BOB_CHAIN_ID);
           const balance = await getBalance(asset, account, provider);
           const decimalBalance = decimalic(fromWei(balance, asset.decimals));

--- a/apps/frontend/src/utils/aave/AaveWithdrawTransactionsFactory.ts
+++ b/apps/frontend/src/utils/aave/AaveWithdrawTransactionsFactory.ts
@@ -9,7 +9,6 @@ import {
   Transaction,
   TransactionType,
 } from '../../app/3_organisms/TransactionStepDialog/TransactionStepDialog.types';
-import { AAVE_CONTRACT_ADDRESSES } from '../../constants/aave';
 import { translations } from '../../locales/i18n';
 import { TransactionFactoryOptions } from '../../types/aave';
 import { prepareApproveTransaction } from '../transactions';
@@ -42,10 +41,7 @@ export class AaveWithdrawTransactionsFactory {
     isMaxAmount: boolean,
     opts?: TransactionFactoryOptions,
   ): Promise<Transaction[]> {
-    if (
-      token.isNative ||
-      token.address.toLowerCase() === AAVE_CONTRACT_ADDRESSES.WETH.toLowerCase()
-    ) {
+    if (token.isNative) {
       return this.withdrawNative(amount, isMaxAmount, opts);
     } else return this.withdrawToken(token, amount, isMaxAmount, opts);
   }


### PR DESCRIPTION
# fix(native): Show WETH asset in dashboard

## Description
This PR fixes an issue where WETH (Wrapped Ether) was not being displayed correctly in native token-related contract interactions. The update ensures that WETH is properly recognized and shown in relevant operations.

## Changes
- Fixed logic to correctly **display WETH** in contract interactions.
