### PR TITLE
fix: add more timeframes

### DIFF
--- a/apps/frontend/src/app/5_pages/AaveReserveOverviewPage/components/SupplyDetailsGraph/SupplyDetailsGraph.tsx
+++ b/apps/frontend/src/app/5_pages/AaveReserveOverviewPage/components/SupplyDetailsGraph/SupplyDetailsGraph.tsx
@@ -132,14 +132,16 @@ export const SupplyDetailsGraph: FC<SupplyDetailsGraphProps> = ({
           />
         </div>
 
-        <Chart
-          input={{
-            data: supplyChartData,
-            label: t(pageTranslations.chart.suppApr),
-            lineColor: theme.colors['primary-30'],
-          }}
-          onTimeRangeChange={setTimeRange}
-        />
+        {reserve.borrowingEnabled && (
+          <Chart
+            input={{
+              data: supplyChartData,
+              label: t(pageTranslations.chart.suppApr),
+              lineColor: theme.colors['primary-30'],
+            }}
+            onTimeRangeChange={setTimeRange}
+          />
+        )}
 
         <div className="space-y-6">
           {/* collateral usage */}

--- a/apps/frontend/src/app/5_pages/AaveReserveOverviewPage/components/TimeRangeButtons/TimeRangeButtons.tsx
+++ b/apps/frontend/src/app/5_pages/AaveReserveOverviewPage/components/TimeRangeButtons/TimeRangeButtons.tsx
@@ -24,7 +24,26 @@ export const TimeRangeButtons: FC<TimeRangeButtonsProps> = ({ onChange }) => {
 
   return (
     <div className="flex space-x-2 justify-end mb-4">
-      {' '}
+      <button
+        className={`py-1.5 px-4 rounded-md text-sm font-medium ${
+          activeRange === ESupportedTimeRanges.OneDay
+            ? 'bg-gray-50 text-white'
+            : 'bg-gray-70 text-gray-400'
+        }`}
+        onClick={() => handleClick(ESupportedTimeRanges.OneDay)}
+      >
+        {ESupportedTimeRanges.OneDay}
+      </button>
+      <button
+        className={`py-1.5 px-4 rounded-md text-sm font-medium ${
+          activeRange === ESupportedTimeRanges.OneWeek
+            ? 'bg-gray-50 text-white'
+            : 'bg-gray-70 text-gray-400'
+        }`}
+        onClick={() => handleClick(ESupportedTimeRanges.OneWeek)}
+      >
+        {ESupportedTimeRanges.OneWeek}
+      </button>
       <button
         className={`py-1.5 px-4 rounded-md text-sm font-medium ${
           activeRange === ESupportedTimeRanges.OneMonth

--- a/apps/frontend/src/hooks/aave/useAaveReservesHistory.tsx
+++ b/apps/frontend/src/hooks/aave/useAaveReservesHistory.tsx
@@ -6,6 +6,8 @@ import dayjs from 'dayjs';
 import { AAVE_CONTRACT_ADDRESSES } from '../../constants/aave';
 
 export enum ESupportedTimeRanges {
+  OneDay = '1d',
+  OneWeek = '1w',
   OneMonth = '1m',
   ThreeMonths = '3m',
   SixMonths = '6m',
@@ -64,6 +66,16 @@ const resolutionForTimeRange = (
   timeRange: ReserveRateTimeRange,
 ): RatesHistoryParams => {
   switch (timeRange) {
+    case ESupportedTimeRanges.OneDay:
+      return {
+        from: dayjs().subtract(1, 'day').unix(),
+        resolutionInHours: 6,
+      };
+    case ESupportedTimeRanges.OneWeek:
+      return {
+        from: dayjs().subtract(1, 'week').unix(),
+        resolutionInHours: 6,
+      };
     case ESupportedTimeRanges.OneMonth:
       return {
         from: dayjs().subtract(1, 'month').unix(),

--- a/apps/frontend/src/locales/en/translations.json
+++ b/apps/frontend/src/locales/en/translations.json
@@ -890,7 +890,7 @@
             "noData": "You don't have any deposits/loans yet"
         },
         "lendAssetsList": {
-            "title": "Assets to lend",
+            "title": "Assets to supply",
             "showZeroBalances": "Show assets with 0 balance",
             "walletBalance": "Wallet balance",
             "canBeCollateral": "Can be collateral"


### PR DESCRIPTION
This PR addresses the issues identified in the latest report.

**Key Considerations:**

**Issue:** “Interest Rate Strategy” link (top right) redirects to the explorer and the pool contract.
**Description:** The link now points to: https://bob-sepolia.explorer.gobob.xyz/address/0xF8FD42C5187865f3d6008492dbdFC5F2d9406EC4?tab=contract. However, it can be configured in aave/constants if needed for future implementations. Aave was used as a reference for this decision.

**Issue:** Chart responsiveness
**Description:** The Sovryn library is being used, so the behavior is expected to remain unchanged.